### PR TITLE
Add document upload and management for surgery requests

### DIFF
--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Document;
+use App\Models\SurgeryRequest;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class DocumentController extends Controller
+{
+    public function store(Request $request, SurgeryRequest $surgeryRequest)
+    {
+        $this->authorize('update', $surgeryRequest);
+
+        $data = $request->validate([
+            'file' => ['required', 'file'],
+        ]);
+
+        $file = $data['file'];
+        $path = $file->store('documents');
+
+        $surgeryRequest->documents()->create([
+            'path' => $path,
+            'original_name' => $file->getClientOriginalName(),
+        ]);
+
+        return back()->with('ok', 'Documento enviado!');
+    }
+
+    public function destroy(SurgeryRequest $surgeryRequest, Document $document)
+    {
+        $this->authorize('update', $surgeryRequest);
+        abort_unless($document->surgery_request_id === $surgeryRequest->id, 404);
+
+        Storage::delete($document->path);
+        $document->delete();
+
+        return back()->with('ok', 'Documento removido.');
+    }
+}

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Document extends Model
+{
+    protected $fillable = [
+        'surgery_request_id',
+        'path',
+        'original_name',
+    ];
+
+    public function surgeryRequest()
+    {
+        return $this->belongsTo(SurgeryRequest::class);
+    }
+}

--- a/app/Models/SurgeryRequest.php
+++ b/app/Models/SurgeryRequest.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Document;
 
 class SurgeryRequest extends Model
 {

--- a/database/migrations/2025_08_18_185700_create_documents_table.php
+++ b/database/migrations/2025_08_18_185700_create_documents_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('documents', function (Blueprint $t) {
+            $t->id();
+            $t->foreignId('surgery_request_id')
+                ->nullable()
+                ->constrained('surgery_requests')
+                ->cascadeOnUpdate()
+                ->nullOnDelete();
+            $t->string('path');
+            $t->string('original_name');
+            $t->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('documents');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\SurgeryRequestController;
 use App\Http\Controllers\ChecklistController;
+use App\Http\Controllers\DocumentController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -57,6 +58,11 @@ Route::middleware('auth')->group(function () {
             ->name('surgery-requests.edit');
         Route::match(['put', 'patch'], '/surgery-requests/{request}', [SurgeryRequestController::class, 'update'])
             ->name('surgery-requests.update');
+
+        Route::post('/surgery-requests/{request}/documents', [DocumentController::class, 'store'])
+            ->name('surgery-requests.documents.store');
+        Route::delete('/surgery-requests/{request}/documents/{document}', [DocumentController::class, 'destroy'])
+            ->name('surgery-requests.documents.destroy');
     });
 
     /**


### PR DESCRIPTION
## Summary
- add Document model and documents table migration
- expose surgery request document upload and delete endpoints
- wire document relations to surgery requests

## Testing
- `composer install --ignore-platform-reqs`
- `php artisan key:generate`
- `./vendor/bin/phpunit` *(fails: Tests: 30, Failures: 12)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a9522ea4832a8d35b79b780a7b2a