### PR TITLE
Add validation and tests for document uploads

### DIFF
--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -14,13 +14,14 @@ class DocumentController extends Controller
         $this->authorize('update', $surgeryRequest);
 
         $data = $request->validate([
-            'file' => ['required', 'file'],
+            'file' => ['required', 'file', 'mimes:pdf,jpg,png', 'max:2048'],
         ]);
 
         $file = $data['file'];
         $path = $file->store('documents');
 
         $surgeryRequest->documents()->create([
+            'surgery_request_id' => $surgeryRequest->id,
             'path' => $path,
             'original_name' => $file->getClientOriginalName(),
         ]);

--- a/tests/Feature/DocumentTest.php
+++ b/tests/Feature/DocumentTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\SurgeryRequest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Database\Seeders\RolesSeeder;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class DocumentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    protected function makeRequest(User $doctor): SurgeryRequest
+    {
+        return SurgeryRequest::create([
+            'doctor_id' => $doctor->id,
+            'date' => now()->addDay(),
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'patient_name' => 'Patient',
+            'procedure' => 'Proc',
+            'status' => 'requested',
+            'meta' => [],
+        ]);
+    }
+
+    public function test_doctor_can_upload_valid_document(): void
+    {
+        Storage::fake('local');
+        $doctor = User::factory()->create();
+        $doctor->assignRole('admin');
+        $request = $this->makeRequest($doctor);
+
+        $file = UploadedFile::fake()->create('doc.pdf', 500, 'application/pdf');
+
+        $response = $this->actingAs($doctor)
+            ->withHeader('Accept', 'text/html')
+            ->post("/surgery-requests/{$request->id}/documents", [
+                'file' => $file,
+            ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('ok', 'Documento enviado!');
+        $this->assertDatabaseCount('documents', 1);
+        $this->assertDatabaseHas('documents', [
+            'original_name' => 'doc.pdf',
+        ]);
+        Storage::disk('local')->assertExists('documents/' . $file->hashName());
+    }
+
+    public function test_invalid_file_type_is_rejected(): void
+    {
+        Storage::fake('local');
+        $doctor = User::factory()->create();
+        $doctor->assignRole('admin');
+        $request = $this->makeRequest($doctor);
+
+        $file = UploadedFile::fake()->create('file.txt', 100, 'text/plain');
+
+        $response = $this->actingAs($doctor)
+            ->withHeader('Accept', 'text/html')
+            ->post("/surgery-requests/{$request->id}/documents", [
+                'file' => $file,
+            ]);
+        $response->assertSessionHasErrors('file');
+        $this->assertDatabaseCount('documents', 0);
+    }
+
+    public function test_invalid_file_size_is_rejected(): void
+    {
+        Storage::fake('local');
+        $doctor = User::factory()->create();
+        $doctor->assignRole('admin');
+        $request = $this->makeRequest($doctor);
+
+        $file = UploadedFile::fake()->create('big.pdf', 3000, 'application/pdf');
+
+        $response = $this->actingAs($doctor)
+            ->withHeader('Accept', 'text/html')
+            ->post("/surgery-requests/{$request->id}/documents", [
+                'file' => $file,
+            ]);
+
+        $response->assertSessionHasErrors('file');
+        $this->assertDatabaseCount('documents', 0);
+    }
+}


### PR DESCRIPTION
## Summary
- validate document uploads for pdf, jpg, and png up to 2MB
- cover document upload validation scenarios in feature tests

## Testing
- `./vendor/bin/phpunit tests/Feature/DocumentTest.php`
- `./vendor/bin/phpunit` *(fails: Tests\Feature\SurgeryRequestTest::test_nurse_can_update_checklist_item, Tests\Feature\SurgeryRequestTest::test_nurse_can_approve_request, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68ac76613884832a807af05783b28f8b