### PR TITLE
Update default admin seeder credentials

### DIFF
--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -20,7 +20,7 @@ class RolesSeeder extends Seeder
 
         // Cria um usuário admin padrão
         $user = User::firstOrCreate(
-            ['email' => 'admin@hospital.local'],
+            ['email' => 'jonnnatha'],
             ['name' => 'Admin', 'password' => bcrypt('123')]
         );
 


### PR DESCRIPTION
## Summary
- set admin user's login to `jonnnatha` and ensure password uses `bcrypt('123')`

## Testing
- `php artisan db:seed --class=RolesSeeder --force` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `php artisan test` *(fails: multiple tests due to missing env/config)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7bd59abc832a9b322e2a461b7317