### PR TITLE
Add role-specific dashboards and routing

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,6 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
+    // Redirect after login to a route that forwards to the appropriate dashboard
     public const HOME = '/dashboard';
 
     /**

--- a/resources/js/Pages/Admin/Dashboard.vue
+++ b/resources/js/Pages/Admin/Dashboard.vue
@@ -1,0 +1,24 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head } from '@inertiajs/vue3';
+</script>
+
+<template>
+    <Head title="Admin Dashboard" />
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Admin Dashboard</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        Bem-vindo, administrador!
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>
+

--- a/resources/js/Pages/Enfermeiro/Dashboard.vue
+++ b/resources/js/Pages/Enfermeiro/Dashboard.vue
@@ -1,0 +1,24 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head } from '@inertiajs/vue3';
+</script>
+
+<template>
+    <Head title="Dashboard Enfermeiro" />
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Dashboard Enfermeiro</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        Bem-vindo, enfermeiro! Acompanhe os pedidos de cirurgia.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>
+

--- a/resources/js/Pages/Medico/Dashboard.vue
+++ b/resources/js/Pages/Medico/Dashboard.vue
@@ -1,0 +1,24 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head } from '@inertiajs/vue3';
+</script>
+
+<template>
+    <Head title="Dashboard Médico" />
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Dashboard Médico</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        Bem-vindo, médico! Gerencie suas solicitações de cirurgia.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\ChecklistController;
 use App\Http\Controllers\DocumentController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Http\Request;
 use Inertia\Inertia;
 
 Route::get('/', function () {
@@ -17,9 +18,31 @@ Route::get('/', function () {
     ]);
 });
 
-Route::get('/dashboard', function () {
-    return Inertia::render('Dashboard');
+Route::get('/dashboard', function (Request $request) {
+    if ($request->user()->hasRole('admin')) {
+        return redirect()->route('admin.dashboard');
+    }
+    if ($request->user()->hasRole('medico')) {
+        return redirect()->route('medico.dashboard');
+    }
+    if ($request->user()->hasRole('enfermeiro')) {
+        return redirect()->route('enfermeiro.dashboard');
+    }
+
+    abort(403);
 })->middleware(['auth', 'verified'])->name('dashboard');
+
+Route::middleware(['auth', 'verified', 'role:admin'])->get('/admin/dashboard', function () {
+    return Inertia::render('Admin/Dashboard');
+})->name('admin.dashboard');
+
+Route::middleware(['auth', 'verified', 'role:medico'])->get('/medico/dashboard', function () {
+    return Inertia::render('Medico/Dashboard');
+})->name('medico.dashboard');
+
+Route::middleware(['auth', 'verified', 'role:enfermeiro'])->get('/enfermeiro/dashboard', function () {
+    return Inertia::render('Enfermeiro/Dashboard');
+})->name('enfermeiro.dashboard');
 
 Route::middleware('auth')->group(function () {
     // Perfil do usuário (Breeze)


### PR DESCRIPTION
## Summary
- create Admin, Medico and Enfermeiro dashboard Vue components
- add named routes for each role and redirect /dashboard based on user role
- document dashboard redirect in RouteServiceProvider

## Testing
- `npm run build` *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: inertiajs/inertia-laravel requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7bdb49ec832a88dd5d961eb33c7a