### PR TITLE
feat: add role-based dashboards and routing

### DIFF
--- a/resources/js/Pages/Admin/Dashboard.vue
+++ b/resources/js/Pages/Admin/Dashboard.vue
@@ -1,0 +1,22 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head } from '@inertiajs/vue3';
+</script>
+
+<template>
+    <Head title="Admin Dashboard" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Admin Dashboard</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">Bem-vindo ao painel do administrador.</div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Enfermeiro/Dashboard.vue
+++ b/resources/js/Pages/Enfermeiro/Dashboard.vue
@@ -1,0 +1,22 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head } from '@inertiajs/vue3';
+</script>
+
+<template>
+    <Head title="Dashboard do Enfermeiro" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Dashboard do Enfermeiro</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">Bem-vindo ao painel do enfermeiro.</div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Medico/Dashboard.vue
+++ b/resources/js/Pages/Medico/Dashboard.vue
@@ -1,0 +1,22 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head } from '@inertiajs/vue3';
+</script>
+
+<template>
+    <Head title="Dashboard do Médico" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Dashboard do Médico</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">Bem-vindo ao painel do médico.</div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,8 +17,34 @@ Route::get('/', function () {
     ]);
 });
 
+Route::middleware(['auth', 'role:admin'])->get('/admin/dashboard', function () {
+    return Inertia::render('Admin/Dashboard');
+})->name('admin.dashboard');
+
+Route::middleware(['auth', 'role:medico'])->get('/medico/dashboard', function () {
+    return Inertia::render('Medico/Dashboard');
+})->name('medico.dashboard');
+
+Route::middleware(['auth', 'role:enfermeiro'])->get('/enfermeiro/dashboard', function () {
+    return Inertia::render('Enfermeiro/Dashboard');
+})->name('enfermeiro.dashboard');
+
 Route::get('/dashboard', function () {
-    return Inertia::render('Dashboard');
+    $user = auth()->user();
+
+    if ($user->hasRole('admin')) {
+        return to_route('admin.dashboard');
+    }
+
+    if ($user->hasRole('medico')) {
+        return to_route('medico.dashboard');
+    }
+
+    if ($user->hasRole('enfermeiro')) {
+        return to_route('enfermeiro.dashboard');
+    }
+
+    abort(403);
 })->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
## Summary
- add dashboards for admin, médico and enfermeiro
- route each role to its own dashboard
- redirect generic dashboard to the appropriate page

## Testing
- `composer install --ignore-platform-reqs`
- `php artisan test` *(fails: login screen can be rendered)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7bdb8498832aabf303e3a861fc9e