### PR TITLE
Update registration to use hierarquia and nome fields

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -32,15 +32,16 @@ class RegisteredUserController extends Controller
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'name' => 'required|string|max:255',
-            'email' => 'required|string|lowercase|email|max:255|unique:'.User::class,
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'hierarquia' => 'required|string|max:255',
+            'nome' => 'required|string|max:255',
+            'senha' => ['required', 'same:confirmacao_senha', Rules\Password::defaults()],
+            'confirmacao_senha' => 'required',
         ]);
 
         $user = User::create([
-            'name' => $request->name,
-            'email' => $request->email,
-            'password' => Hash::make($request->password),
+            'hierarquia' => $request->hierarquia,
+            'nome' => $request->nome,
+            'senha' => Hash::make($request->senha),
         ]);
 
         event(new Registered($user));

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -19,18 +18,17 @@ class User extends Authenticatable
      * The attributes that are mass assignable.
      */
     protected $fillable = [
-        'name',
-        'email',
-        'password',
+        'hierarquia',
+        'nome',
+        'senha',
     ];
 
     protected $hidden = [
-        'password',
+        'senha',
         'remember_token',
     ];
 
     protected $casts = [
-        'email_verified_at' => 'datetime',
-        'password' => 'hashed',
+        'senha' => 'hashed',
     ];
 }

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -13,10 +13,9 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
-            $table->string('email')->unique();
-            $table->timestamp('email_verified_at')->nullable();
-            $table->string('password');
+            $table->string('hierarquia');
+            $table->string('nome');
+            $table->string('senha');
             $table->rememberToken();
             $table->timestamps();
         });

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -7,15 +7,15 @@ import TextInput from '@/Components/TextInput.vue';
 import { Head, Link, useForm } from '@inertiajs/vue3';
 
 const form = useForm({
-    name: '',
-    email: '',
-    password: '',
-    password_confirmation: '',
+    hierarquia: '',
+    nome: '',
+    senha: '',
+    confirmacao_senha: '',
 });
 
 const submit = () => {
     form.post(route('register'), {
-        onFinish: () => form.reset('password', 'password_confirmation'),
+        onFinish: () => form.reset('senha', 'confirmacao_senha'),
     });
 };
 </script>
@@ -26,64 +26,64 @@ const submit = () => {
 
         <form @submit.prevent="submit">
             <div>
-                <InputLabel for="name" value="Name" />
+                <InputLabel for="hierarquia" value="Hierarquia" />
 
                 <TextInput
-                    id="name"
+                    id="hierarquia"
                     type="text"
                     class="mt-1 block w-full"
-                    v-model="form.name"
+                    v-model="form.hierarquia"
                     required
                     autofocus
-                    autocomplete="name"
+                    autocomplete="hierarquia"
                 />
 
-                <InputError class="mt-2" :message="form.errors.name" />
+                <InputError class="mt-2" :message="form.errors.hierarquia" />
             </div>
 
             <div class="mt-4">
-                <InputLabel for="email" value="Email" />
+                <InputLabel for="nome" value="Nome" />
 
                 <TextInput
-                    id="email"
-                    type="email"
+                    id="nome"
+                    type="text"
                     class="mt-1 block w-full"
-                    v-model="form.email"
+                    v-model="form.nome"
                     required
-                    autocomplete="username"
+                    autocomplete="nome"
                 />
 
-                <InputError class="mt-2" :message="form.errors.email" />
+                <InputError class="mt-2" :message="form.errors.nome" />
             </div>
 
             <div class="mt-4">
-                <InputLabel for="password" value="Password" />
+                <InputLabel for="senha" value="Senha" />
 
                 <TextInput
-                    id="password"
+                    id="senha"
                     type="password"
                     class="mt-1 block w-full"
-                    v-model="form.password"
+                    v-model="form.senha"
                     required
                     autocomplete="new-password"
                 />
 
-                <InputError class="mt-2" :message="form.errors.password" />
+                <InputError class="mt-2" :message="form.errors.senha" />
             </div>
 
             <div class="mt-4">
-                <InputLabel for="password_confirmation" value="Confirm Password" />
+                <InputLabel for="confirmacao_senha" value="Confirmação de Senha" />
 
                 <TextInput
-                    id="password_confirmation"
+                    id="confirmacao_senha"
                     type="password"
                     class="mt-1 block w-full"
-                    v-model="form.password_confirmation"
+                    v-model="form.confirmacao_senha"
                     required
                     autocomplete="new-password"
                 />
 
-                <InputError class="mt-2" :message="form.errors.password_confirmation" />
+                <InputError class="mt-2" :message="form.errors.confirmacao_senha" />
             </div>
 
             <div class="flex items-center justify-end mt-4">


### PR DESCRIPTION
## Summary
- replace registration form fields with `hierarquia`, `nome`, `senha`, and `confirmacao_senha`
- save and validate new attributes in registration controller
- switch User model and migration to new column names

## Testing
- `php artisan test` *(fails: QueryException during database seeding)*

------
https://chatgpt.com/codex/tasks/task_e_68ac98bea95c832a83cf786132dbe83d