### PR TITLE
Use nome and hierarquia in layout

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -45,7 +45,7 @@ const showingNavigationDropdown = ref(false);
                                                 type="button"
                                                 class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150"
                                             >
-                                                {{ $page.props.auth.user.name }}
+                                                {{ $page.props.auth.user.nome }}
 
                                                 <svg
                                                     class="ms-2 -me-0.5 h-4 w-4"
@@ -121,9 +121,9 @@ const showingNavigationDropdown = ref(false);
                     <div class="pt-4 pb-1 border-t border-gray-200">
                         <div class="px-4">
                             <div class="font-medium text-base text-gray-800">
-                                {{ $page.props.auth.user.name }}
+                                {{ $page.props.auth.user.nome }}
                             </div>
-                            <div class="font-medium text-sm text-gray-500">{{ $page.props.auth.user.email }}</div>
+                            <div class="font-medium text-sm text-gray-500">{{ $page.props.auth.user.hierarquia }}</div>
                         </div>
 
                         <div class="mt-3 space-y-1">


### PR DESCRIPTION
## Summary
- show `auth.user.nome` instead of `auth.user.name` in desktop and responsive layouts
- display user's `hierarquia` where email was previously shown

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: require(/workspace/cirurgias/vendor/autoload.php): Failed to open stream)*
- `npm run build` *(fails: Could not resolve "../../vendor/tightenco/ziggy")*

------
https://chatgpt.com/codex/tasks/task_e_68ac9b39fcb8832aa8fda602a17086be