### PR TITLE
Use localized user fields in RolesSeeder

### DIFF
--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -2,9 +2,9 @@
 
 namespace Database\Seeders;
 
+use App\Models\User;
 use Illuminate\Database\Seeder;
 use Spatie\Permission\Models\Role;
-use App\Models\User;
 
 class RolesSeeder extends Seeder
 {
@@ -14,14 +14,14 @@ class RolesSeeder extends Seeder
     public function run(): void
     {
         // Cria os papéis
-        $admin     = Role::firstOrCreate(['name' => 'admin']);
+        $admin = Role::firstOrCreate(['name' => 'admin']);
         $enfermeiro = Role::firstOrCreate(['name' => 'enfermeiro']);
-        $medico     = Role::firstOrCreate(['name' => 'medico']);
+        $medico = Role::firstOrCreate(['name' => 'medico']);
 
         // Cria um usuário admin padrão
         $user = User::firstOrCreate(
-            ['email' => 'jonnnatha'],
-            ['name' => 'Admin', 'password' => bcrypt('123')]
+            ['hierarquia' => 'admin', 'nome' => 'Admin'],
+            ['senha' => bcrypt('123')]
         );
 
         $user->assignRole($admin);


### PR DESCRIPTION
## Summary
- use nome, hierarquia and senha when creating default admin

## Testing
- `php artisan migrate:fresh --seed`
- `sqlite3 database/database.sqlite "select nome, hierarquia, senha from users;"`
- `php artisan test` *(fails: login screen can be rendered)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9b3a5f8c832ab4278353990ffb62