### PR TITLE
Update auth tests for custom user fields

### DIFF
--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -23,7 +23,7 @@ class AuthenticationTest extends TestCase
         $user = User::factory()->create();
 
         $response = $this->post('/login', [
-            'email' => $user->email,
+            'nome' => $user->nome,
             'password' => 'password',
         ]);
 
@@ -36,7 +36,7 @@ class AuthenticationTest extends TestCase
         $user = User::factory()->create();
 
         $this->post('/login', [
-            'email' => $user->email,
+            'nome' => $user->nome,
             'password' => 'wrong-password',
         ]);
 

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -20,8 +20,8 @@ class RegistrationTest extends TestCase
     public function test_new_users_can_register(): void
     {
         $response = $this->post('/register', [
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+            'nome' => 'Test User',
+            'hierarquia' => 'admin',
             'password' => 'password',
             'password_confirmation' => 'password',
         ]);


### PR DESCRIPTION
## Summary
- Update registration test to send nome/hierarquia fields
- Authenticate using nome in login tests

## Testing
- `php artisan test` *(fails: registration and other auth tests failing; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9b3a128c832a8fc252614b92b4e8