### PR TITLE
Add hierarquia column migration

### DIFF
--- a/database/migrations/2025_08_25_174709_add_hierarquia_to_users_table.php
+++ b/database/migrations/2025_08_25_174709_add_hierarquia_to_users_table.php
@@ -11,12 +11,8 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('users', function (Blueprint $table) {
-            $table->id();
-            $table->string('nome');
-            $table->string('senha');
-            $table->rememberToken();
-            $table->timestamps();
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('hierarquia')->after('nome');
         });
     }
 
@@ -25,6 +21,8 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('users');
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('hierarquia');
+        });
     }
 };


### PR DESCRIPTION
## Summary
- remove hierarquia column from initial users table migration
- add migration adding hierarquia column after nome

## Testing
- `php artisan migrate`
- `php artisan test` (fails: login screen can be rendered)

------
https://chatgpt.com/codex/tasks/task_e_68aca14ddc6c832a906cccfe9f115ca3