### PR TITLE
Simplify admin user creation in RolesSeeder

### DIFF
--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -20,8 +20,8 @@ class RolesSeeder extends Seeder
 
         // Cria um usuário admin padrão
         $user = User::firstOrCreate(
-            ['hierarquia' => 'admin', 'nome' => 'Admin'],
-            ['senha' => bcrypt('123')]
+            ['nome' => 'Admin'],
+            ['hierarquia' => 'admin', 'senha' => '123']
         );
 
         $user->assignRole($admin);


### PR DESCRIPTION
## Summary
- simplify default admin seeder to use firstOrCreate with plain password

## Testing
- `php artisan migrate`
- `php artisan db:seed`
- `php artisan test` *(fails: table users has no column named email_verified_at, login screen 500, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aca14f58c8832a9178f69d09e9bc57