### PR TITLE
Replace email with hierarquia in user registration

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -33,13 +33,13 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'nome' => 'required|string|max:255',
-            'email' => 'required|string|lowercase|email|max:255|unique:'.User::class,
+            'hierarquia' => 'required|string|max:255',
             'senha' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
         $user = User::create([
             'nome' => $request->nome,
-            'email' => $request->email,
+            'hierarquia' => $request->hierarquia,
             'senha' => Hash::make($request->senha),
         ]);
 

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -8,7 +8,7 @@ import { Head, Link, useForm } from '@inertiajs/vue3';
 
 const form = useForm({
     nome: '',
-    email: '',
+    hierarquia: '',
     senha: '',
     senha_confirmation: '',
 });
@@ -42,18 +42,17 @@ const submit = () => {
             </div>
 
             <div class="mt-4">
-                <InputLabel for="email" value="Email" />
+                <InputLabel for="hierarquia" value="Hierarquia" />
 
                 <TextInput
-                    id="email"
-                    type="email"
+                    id="hierarquia"
+                    type="text"
                     class="mt-1 block w-full"
-                    v-model="form.email"
+                    v-model="form.hierarquia"
                     required
-                    autocomplete="username"
                 />
 
-                <InputError class="mt-2" :message="form.errors.email" />
+                <InputError class="mt-2" :message="form.errors.hierarquia" />
             </div>
 
             <div class="mt-4">

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -28,5 +28,10 @@ class RegistrationTest extends TestCase
 
         $this->assertAuthenticated();
         $response->assertRedirect(RouteServiceProvider::HOME);
+
+        $this->assertDatabaseHas('users', [
+            'nome' => 'Test User',
+            'hierarquia' => 'admin',
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- Persist user `hierarquia` during registration instead of email
- Collect `hierarquia` on the registration form
- Verify stored `hierarquia` in registration test

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install --no-progress --no-interaction` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68acb04400a0832abb3d7e6817e92a6d