### PR TITLE
Remove unused email verification wiring

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\ProfileUpdateRequest;
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -19,7 +18,6 @@ class ProfileController extends Controller
     public function edit(Request $request): Response
     {
         return Inertia::render('Profile/Edit', [
-            'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
             'status' => session('status'),
         ]);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;


### PR DESCRIPTION
## Summary
- remove unused `MustVerifyEmail` import from user model
- drop `MustVerifyEmail` check from profile controller

## Testing
- `composer install --no-interaction --no-progress` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0, but 8.4.11 is installed)*

------
https://chatgpt.com/codex/tasks/task_e_68acb044eab4832abc8f43dad56faabd