### PR TITLE
Replace email column in password reset migration

### DIFF
--- a/database/migrations/2014_10_12_100000_create_password_reset_tokens_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_reset_tokens_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('password_reset_tokens', function (Blueprint $table) {
-            $table->string('email')->primary();
+            $table->foreignId('user_id')->primary()->constrained()->cascadeOnDelete();
             $table->string('token');
             $table->timestamp('created_at')->nullable();
         });


### PR DESCRIPTION
## Summary
- use `user_id` foreign key instead of `email` in password reset tokens migration

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=/workspace/cirurgias/database/database.sqlite php artisan migrate:refresh --force`


------
https://chatgpt.com/codex/tasks/task_e_68acb3e2718c832a9c54b066c28127fd