### PR TITLE
Use lowercase admin name and case-insensitive login

### DIFF
--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -41,7 +41,7 @@ class LoginRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
 
-        if (! Auth::attempt(['nome' => $this->nome, 'password' => $this->senha], $this->boolean('remember'))) {
+        if (! Auth::attempt(['nome' => Str::lower($this->nome), 'password' => $this->senha], $this->boolean('remember'))) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([

--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -21,7 +21,7 @@ class RolesSeeder extends Seeder
 
         // Cria um usuário admin padrão
         $user = User::firstOrCreate(
-            ['nome' => 'Admin'],
+            ['nome' => 'adm'],
             ['hierarquia' => 'admin', 'senha' => Hash::make('123')]
         );
 


### PR DESCRIPTION
## Summary
- seed default admin user with lowercase `adm`
- normalize login name to lowercase to avoid case-sensitive logins

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=/workspace/cirurgias/database/database.sqlite php artisan migrate --force`
- `DB_CONNECTION=sqlite DB_DATABASE=/workspace/cirurgias/database/database.sqlite php artisan db:seed --class=RolesSeeder --force`
- `sqlite3 database/database.sqlite "select id,nome,hierarquia from users;"`
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000]: General error: 1 table users has no column named email)*

------
https://chatgpt.com/codex/tasks/task_e_68acba6cdd18832ab868d9e2caeff611