### PR TITLE
Add admin user creation form and routes

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class UserController extends Controller
+{
+    public function create()
+    {
+        return Inertia::render('Admin/CreateUser');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nome' => ['required', 'string', 'max:255'],
+            'senha' => ['required', 'confirmed'],
+            'hierarquia' => ['required', 'in:enfermeiro,medico'],
+        ]);
+
+        $user = User::create($data);
+        $user->assignRole($request->hierarquia);
+
+        return redirect()->route('admin.dashboard')->with('success', 'Usuário criado com sucesso.');
+    }
+}

--- a/resources/js/Pages/Admin/CreateUser.vue
+++ b/resources/js/Pages/Admin/CreateUser.vue
@@ -1,0 +1,74 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import { Head, useForm } from '@inertiajs/vue3';
+
+const form = useForm({
+    nome: '',
+    hierarquia: '',
+    senha: '',
+    senha_confirmation: '',
+});
+
+const submit = () => {
+    form.post(route('admin.users.store'), {
+        onFinish: () => form.reset('senha', 'senha_confirmation'),
+    });
+};
+</script>
+
+<template>
+    <Head title="Criar Usuário" />
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Criar Usuário</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <form @submit.prevent="submit" class="space-y-4">
+                            <div>
+                                <InputLabel for="nome" value="Nome" />
+                                <TextInput id="nome" v-model="form.nome" type="text" class="mt-1 block w-full" autofocus />
+                                <InputError class="mt-2" :message="form.errors.nome" />
+                            </div>
+
+                            <div>
+                                <InputLabel for="hierarquia" value="Hierarquia" />
+                                <select id="hierarquia" v-model="form.hierarquia" class="mt-1 block w-full">
+                                    <option value="" disabled>Selecione</option>
+                                    <option value="enfermeiro">Enfermeiro</option>
+                                    <option value="medico">Médico</option>
+                                </select>
+                                <InputError class="mt-2" :message="form.errors.hierarquia" />
+                            </div>
+
+                            <div>
+                                <InputLabel for="senha" value="Senha" />
+                                <TextInput id="senha" v-model="form.senha" type="password" class="mt-1 block w-full" />
+                                <InputError class="mt-2" :message="form.errors.senha" />
+                            </div>
+
+                            <div>
+                                <InputLabel for="senha_confirmation" value="Confirmar Senha" />
+                                <TextInput id="senha_confirmation" v-model="form.senha_confirmation" type="password" class="mt-1 block w-full" />
+                                <InputError class="mt-2" :message="form.errors.senha_confirmation" />
+                            </div>
+
+                            <div>
+                                <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                                    Salvar
+                                </PrimaryButton>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Admin/Dashboard.vue
+++ b/resources/js/Pages/Admin/Dashboard.vue
@@ -1,6 +1,6 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
-import { Head } from '@inertiajs/vue3';
+import { Head, Link } from '@inertiajs/vue3';
 
 const props = defineProps({
     user: Object,
@@ -18,7 +18,10 @@ const props = defineProps({
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                     <div class="p-6 text-gray-900">
-                        Bem-vindo, administrador {{ props.user.nome }}!
+                        <p>Bem-vindo, administrador {{ props.user.nome }}!</p>
+                        <Link :href="route('admin.users.create')" class="text-blue-500 underline mt-4 inline-block">
+                            Criar novo usuário
+                        </Link>
                     </div>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\SurgeryRequestController;
 use App\Http\Controllers\ChecklistController;
 use App\Http\Controllers\DocumentController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\Admin\UserController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Request;
 
@@ -27,6 +28,11 @@ Route::get('/dashboard', function (Request $request) {
 Route::middleware(['auth','verified','role:admin'])
     ->get('/admin/dashboard',[DashboardController::class,'admin'])
     ->name('admin.dashboard');
+
+Route::middleware(['auth','verified','role:admin'])->group(function () {
+    Route::get('/admin/users/create', [UserController::class, 'create'])->name('admin.users.create');
+    Route::post('/admin/users', [UserController::class, 'store'])->name('admin.users.store');
+});
 
 Route::middleware(['auth','verified','role:medico'])
     ->get('/medico/dashboard',[DashboardController::class,'medico'])

--- a/tests/Feature/Admin/UserCreationTest.php
+++ b/tests/Feature/Admin/UserCreationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class UserCreationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    public function test_admin_can_create_nurse_and_doctor(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
+        $nursePayload = [
+            'nome' => 'Nurse',
+            'hierarquia' => 'enfermeiro',
+            'senha' => 'secret123',
+            'senha_confirmation' => 'secret123',
+        ];
+
+        $this->actingAs($admin)->post('/admin/users', $nursePayload)->assertRedirect();
+        $this->assertDatabaseHas('users', [
+            'nome' => 'Nurse',
+            'hierarquia' => 'enfermeiro',
+        ]);
+        $this->assertTrue(User::where('nome', 'Nurse')->first()->hasRole('enfermeiro'));
+
+        $doctorPayload = [
+            'nome' => 'Doctor',
+            'hierarquia' => 'medico',
+            'senha' => 'secret123',
+            'senha_confirmation' => 'secret123',
+        ];
+
+        $this->actingAs($admin)->post('/admin/users', $doctorPayload)->assertRedirect();
+        $this->assertDatabaseHas('users', [
+            'nome' => 'Doctor',
+            'hierarquia' => 'medico',
+        ]);
+        $this->assertTrue(User::where('nome', 'Doctor')->first()->hasRole('medico'));
+    }
+
+    public function test_non_admins_are_forbidden(): void
+    {
+        $nurse = User::factory()->create();
+        $nurse->assignRole('enfermeiro');
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $this->actingAs($nurse)->get('/admin/users/create')->assertForbidden();
+        $this->actingAs($doctor)->get('/admin/users/create')->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- allow admins to open form and create users with nurse/doctor roles
- add Inertia page for creating users and link from admin dashboard
- cover user creation with feature tests

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0 -> your php version (8.4.11) does not satisfy that requirement)*
- `php artisan test` *(fails: Failed opening required '/workspace/cirurgias/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68adbac07934832aac3eb23db19de877