### PR TITLE
Implement admin user management pages

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -9,6 +9,50 @@ use Inertia\Inertia;
 
 class UserController extends Controller
 {
+    public function index()
+    {
+        $users = User::role(['enfermeiro', 'medico'])->get();
+
+        return Inertia::render('Admin/Users/Index', [
+            'users' => $users,
+        ]);
+    }
+
+    public function edit(User $user)
+    {
+        return Inertia::render('Admin/Users/Edit', [
+            'user' => $user,
+        ]);
+    }
+
+    public function update(Request $request, User $user)
+    {
+        $data = $request->validate([
+            'nome' => ['required', 'string', 'max:255'],
+            'hierarquia' => ['required', 'in:enfermeiro,medico'],
+            'senha' => ['nullable', 'confirmed'],
+        ]);
+
+        $user->nome = $data['nome'];
+        $user->hierarquia = $data['hierarquia'];
+        if (!empty($data['senha'])) {
+            $user->senha = $data['senha'];
+        }
+        $user->save();
+        $user->syncRoles($data['hierarquia']);
+
+        return redirect()->route('admin.users.index')
+            ->with('success', 'Usuário atualizado com sucesso.');
+    }
+
+    public function destroy(User $user)
+    {
+        $user->delete();
+
+        return redirect()->route('admin.users.index')
+            ->with('success', 'Usuário removido com sucesso.');
+    }
+
     public function create()
     {
         return Inertia::render('Admin/CreateUser');

--- a/resources/js/Pages/Admin/Users/Edit.vue
+++ b/resources/js/Pages/Admin/Users/Edit.vue
@@ -1,0 +1,78 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import { Head, useForm } from '@inertiajs/vue3';
+
+const props = defineProps({
+    user: Object,
+});
+
+const form = useForm({
+    nome: props.user.nome,
+    hierarquia: props.user.hierarquia,
+    senha: '',
+    senha_confirmation: '',
+});
+
+const submit = () => {
+    form.put(route('admin.users.update', props.user.id), {
+        onSuccess: () => form.reset('senha', 'senha_confirmation'),
+    });
+};
+</script>
+
+<template>
+    <Head title="Editar Usuário" />
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Editar Usuário</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <form @submit.prevent="submit" class="space-y-4">
+                            <div>
+                                <InputLabel for="nome" value="Nome" />
+                                <TextInput id="nome" v-model="form.nome" type="text" class="mt-1 block w-full" autofocus />
+                                <InputError class="mt-2" :message="form.errors.nome" />
+                            </div>
+
+                            <div>
+                                <InputLabel for="hierarquia" value="Hierarquia" />
+                                <select id="hierarquia" v-model="form.hierarquia" class="mt-1 block w-full">
+                                    <option value="enfermeiro">Enfermeiro</option>
+                                    <option value="medico">Médico</option>
+                                </select>
+                                <InputError class="mt-2" :message="form.errors.hierarquia" />
+                            </div>
+
+                            <div>
+                                <InputLabel for="senha" value="Senha" />
+                                <TextInput id="senha" v-model="form.senha" type="password" class="mt-1 block w-full" />
+                                <InputError class="mt-2" :message="form.errors.senha" />
+                            </div>
+
+                            <div>
+                                <InputLabel for="senha_confirmation" value="Confirmar Senha" />
+                                <TextInput id="senha_confirmation" v-model="form.senha_confirmation" type="password" class="mt-1 block w-full" />
+                                <InputError class="mt-2" :message="form.errors.senha_confirmation" />
+                            </div>
+
+                            <div>
+                                <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                                    Salvar
+                                </PrimaryButton>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>
+

--- a/resources/js/Pages/Admin/Users/Index.vue
+++ b/resources/js/Pages/Admin/Users/Index.vue
@@ -1,0 +1,52 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+
+const props = defineProps({
+    users: Array,
+});
+
+const destroyUser = (id) => {
+    if (confirm('Tem certeza que deseja excluir este usuário?')) {
+        router.delete(route('admin.users.destroy', id));
+    }
+};
+</script>
+
+<template>
+    <Head title="Usuários" />
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Usuários</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <table class="min-w-full">
+                            <thead>
+                                <tr>
+                                    <th class="px-4 py-2 text-left">Nome</th>
+                                    <th class="px-4 py-2 text-left">Hierarquia</th>
+                                    <th class="px-4 py-2"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr v-for="user in users" :key="user.id" class="border-t">
+                                    <td class="px-4 py-2">{{ user.nome }}</td>
+                                    <td class="px-4 py-2">{{ user.hierarquia }}</td>
+                                    <td class="px-4 py-2 text-right">
+                                        <Link :href="route('admin.users.edit', user.id)" class="text-blue-500 mr-2">Editar</Link>
+                                        <button @click="destroyUser(user.id)" class="text-red-500">Excluir</button>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,8 +30,12 @@ Route::middleware(['auth','verified','role:admin'])
     ->name('admin.dashboard');
 
 Route::middleware(['auth','verified','role:admin'])->group(function () {
+    Route::get('/admin/users', [UserController::class, 'index'])->name('admin.users.index');
     Route::get('/admin/users/create', [UserController::class, 'create'])->name('admin.users.create');
     Route::post('/admin/users', [UserController::class, 'store'])->name('admin.users.store');
+    Route::get('/admin/users/{user}/edit', [UserController::class, 'edit'])->name('admin.users.edit');
+    Route::match(['put', 'patch'], '/admin/users/{user}', [UserController::class, 'update'])->name('admin.users.update');
+    Route::delete('/admin/users/{user}', [UserController::class, 'destroy'])->name('admin.users.destroy');
 });
 
 Route::middleware(['auth','verified','role:medico'])


### PR DESCRIPTION
## Summary
- Add index, edit, update and destroy actions for admin users with Inertia responses and flash messages
- Register admin-protected user routes
- Create Vue pages to list and edit nurse/doctor users

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/cirurgias/vendor/autoload.php')*
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68adccb908a8832a816d429b88edc8c9