### PR TITLE
Add user detail view and routing

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -38,6 +38,13 @@ class UserController extends Controller
         return redirect()->route('admin.users.index')->with('success', 'Usuário criado com sucesso.');
     }
 
+    public function show(User $user)
+    {
+        return Inertia::render('Admin/Show', [
+            'user' => $user->only(['id', 'nome', 'hierarquia']),
+        ]);
+    }
+
     public function edit(User $user)
     {
         return Inertia::render('Admin/Edit', [

--- a/resources/js/Pages/Admin/Index.vue
+++ b/resources/js/Pages/Admin/Index.vue
@@ -56,6 +56,7 @@ const deleteUser = () => {
                                     <td class="px-4 py-2">{{ user.nome }}</td>
                                     <td class="px-4 py-2 capitalize">{{ user.hierarquia }}</td>
                                     <td class="px-4 py-2 space-x-2">
+                                        <Link :href="route('admin.users.show', user.id)" class="text-blue-500 underline">Ver</Link>
                                         <Link :href="route('admin.users.edit', user.id)" class="text-blue-500 underline">Editar</Link>
                                         <DangerButton @click="confirmDelete(user)">Excluir</DangerButton>
                                     </td>

--- a/resources/js/Pages/Admin/Show.vue
+++ b/resources/js/Pages/Admin/Show.vue
@@ -1,0 +1,31 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link } from '@inertiajs/vue3';
+
+const props = defineProps({
+    user: Object,
+});
+</script>
+
+<template>
+    <Head title="Detalhes do Usuário" />
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Detalhes do Usuário</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <p><strong>Nome:</strong> {{ user.nome }}</p>
+                        <p class="mt-2 capitalize"><strong>Hierarquia:</strong> {{ user.hierarquia }}</p>
+                        <div class="mt-4">
+                            <Link :href="route('admin.users.index')" class="text-blue-500 underline">Voltar</Link>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,7 @@ Route::middleware(['auth','verified','role:admin'])->group(function () {
     Route::get('/admin/users', [UserController::class, 'index'])->name('admin.users.index');
     Route::get('/admin/users/create', [UserController::class, 'create'])->name('admin.users.create');
     Route::post('/admin/users', [UserController::class, 'store'])->name('admin.users.store');
+    Route::get('/admin/users/{user}', [UserController::class, 'show'])->name('admin.users.show');
     Route::get('/admin/users/{user}/edit', [UserController::class, 'edit'])->name('admin.users.edit');
     Route::put('/admin/users/{user}', [UserController::class, 'update'])->name('admin.users.update');
     Route::delete('/admin/users/{user}', [UserController::class, 'destroy'])->name('admin.users.destroy');

--- a/tests/Feature/Admin/UserManagementTest.php
+++ b/tests/Feature/Admin/UserManagementTest.php
@@ -24,6 +24,33 @@ class UserManagementTest extends TestCase
         $this->markTestSkipped('Inertia assets not available in test environment');
     }
 
+    public function test_admin_can_view_user(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
+        $user = User::factory()->create(['hierarquia' => 'enfermeiro']);
+        $user->assignRole('enfermeiro');
+
+        $this->actingAs($admin)
+            ->get("/admin/users/{$user->id}")
+            ->assertStatus(200);
+    }
+
+    public function test_non_admins_cannot_view_user(): void
+    {
+        $nurse = User::factory()->create();
+        $nurse->assignRole('enfermeiro');
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $user = User::factory()->create(['hierarquia' => 'enfermeiro']);
+        $user->assignRole('enfermeiro');
+
+        $this->actingAs($nurse)->get("/admin/users/{$user->id}")->assertForbidden();
+        $this->actingAs($doctor)->get("/admin/users/{$user->id}")->assertForbidden();
+    }
+
     public function test_admin_can_update_user(): void
     {
         $admin = User::factory()->create();


### PR DESCRIPTION
## Summary
- add show method and route to display user details
- create Admin/Show.vue and link from user index
- test viewing permissions for user details

## Testing
- `php artisan test` *(fails: Tests\Feature\SurgeryRequestTest > nurse can approve request)*

------
https://chatgpt.com/codex/tasks/task_e_68addaf02da4832aa2f04fd2664534fc