### PR TITLE
Align navigation links and inline dropdown

### DIFF
--- a/resources/js/Components/Dropdown.vue
+++ b/resources/js/Components/Dropdown.vue
@@ -45,7 +45,7 @@ const open = ref(false);
 </script>
 
 <template>
-    <div class="relative">
+    <div class="relative inline-block">
         <div @click="open = !open">
             <slot name="trigger" />
         </div>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -33,7 +33,7 @@ const isAdmin = computed(() => {
                             </div>
 
                             <!-- Navigation Links -->
-                            <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
+                            <div class="hidden items-center space-x-8 sm:-my-px sm:ms-10 sm:flex">
                                 <NavLink :href="route('dashboard')" :active="route().current('dashboard')">
                                     Dashboard
                                 </NavLink>


### PR DESCRIPTION
## Summary
- render Dropdown root as inline-block
- vertically center navigation links

## Testing
- `npm run build` *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires PHP ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0 -> your php version (8.4.11) does not satisfy that requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68adec7e5358832ab833916f1aaa03be