### PR TITLE
Add room-based scheduling for surgery requests

### DIFF
--- a/app/Http/Requests/StoreSurgeryRequestRequest.php
+++ b/app/Http/Requests/StoreSurgeryRequestRequest.php
@@ -15,13 +15,14 @@ class StoreSurgeryRequestRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'date'         => ['required','date','after_or_equal:today'],
-            'start_time'   => ['required','date_format:H:i'],
-            'end_time'     => ['required','date_format:H:i','after:start_time'],
-            'patient_name' => ['required','string','max:120'],
-            'procedure'    => ['required','string','max:160'],
+            'date' => ['required', 'date', 'after_or_equal:today'],
+            'start_time' => ['required', 'date_format:H:i'],
+            'duration_minutes' => ['required', 'integer', 'min:1'],
+            'room_number' => ['required', 'integer', 'min:1'],
+            'patient_name' => ['required', 'string', 'max:120'],
+            'procedure' => ['required', 'string', 'max:160'],
             // opcional: confirmar que o médico marcou "docs ok"
-            'confirm_docs' => ['sometimes','boolean'],
+            'confirm_docs' => ['sometimes', 'boolean'],
         ];
     }
 
@@ -29,7 +30,6 @@ class StoreSurgeryRequestRequest extends FormRequest
     {
         return [
             'date.after_or_equal' => 'A data precisa ser hoje ou futura.',
-            'end_time.after'      => 'O término deve ser após o início.',
         ];
     }
 }

--- a/app/Models/SurgeryRequest.php
+++ b/app/Models/SurgeryRequest.php
@@ -3,18 +3,20 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use App\Models\Document;
 
 class SurgeryRequest extends Model
 {
     protected $fillable = [
-        'doctor_id','nurse_id','date','start_time','end_time',
-        'patient_name','procedure','status','meta'
+        'doctor_id', 'nurse_id', 'date', 'start_time', 'end_time',
+        'room_number', 'duration_minutes',
+        'patient_name', 'procedure', 'status', 'meta',
     ];
 
     protected $casts = [
         'date' => 'date',
         'meta' => 'array',
+        'room_number' => 'integer',
+        'duration_minutes' => 'integer',
     ];
 
     public function doctor()

--- a/database/migrations/2025_08_26_000001_add_room_and_duration_to_surgery_requests_table.php
+++ b/database/migrations/2025_08_26_000001_add_room_and_duration_to_surgery_requests_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('surgery_requests', function (Blueprint $table) {
+            $table->unsignedSmallInteger('room_number')->after('end_time')->index();
+            $table->unsignedSmallInteger('duration_minutes')->after('room_number');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('surgery_requests', function (Blueprint $table) {
+            $table->dropColumn(['room_number', 'duration_minutes']);
+        });
+    }
+};

--- a/tests/Feature/DocumentTest.php
+++ b/tests/Feature/DocumentTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
-use App\Models\User;
 use App\Models\SurgeryRequest;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use Database\Seeders\RolesSeeder;
 use Spatie\Permission\PermissionRegistrar;
 use Tests\TestCase;
 
@@ -29,6 +29,8 @@ class DocumentTest extends TestCase
             'date' => now()->addDay(),
             'start_time' => '09:00',
             'end_time' => '10:00',
+            'room_number' => 1,
+            'duration_minutes' => 60,
             'patient_name' => 'Patient',
             'procedure' => 'Proc',
             'status' => 'requested',
@@ -57,7 +59,7 @@ class DocumentTest extends TestCase
         $this->assertDatabaseHas('documents', [
             'original_name' => 'doc.pdf',
         ]);
-        Storage::disk('local')->assertExists('documents/' . $file->hashName());
+        Storage::disk('local')->assertExists('documents/'.$file->hashName());
     }
 
     public function test_invalid_file_type_is_rejected(): void

--- a/tests/Feature/SurgeryRequestTest.php
+++ b/tests/Feature/SurgeryRequestTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Feature;
 
-use App\Models\User;
-use App\Models\SurgeryRequest;
+use App\Http\Controllers\SurgeryRequestController;
 use App\Models\SurgeryChecklistItem;
+use App\Models\SurgeryRequest;
+use App\Models\User;
 use Database\Seeders\RolesSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Spatie\Permission\PermissionRegistrar;
-use App\Http\Controllers\SurgeryRequestController;
 use Illuminate\Http\Request as HttpRequest;
+use Spatie\Permission\PermissionRegistrar;
 use Tests\TestCase;
 
 class SurgeryRequestTest extends TestCase
@@ -31,7 +31,8 @@ class SurgeryRequestTest extends TestCase
         $payload = [
             'date' => now()->addDay()->toDateString(),
             'start_time' => '10:00',
-            'end_time' => '11:00',
+            'duration_minutes' => 60,
+            'room_number' => 1,
             'patient_name' => 'John Doe',
             'procedure' => 'Appendectomy',
         ];
@@ -43,6 +44,9 @@ class SurgeryRequestTest extends TestCase
             'doctor_id' => $doctor->id,
             'patient_name' => 'John Doe',
             'status' => 'requested',
+            'room_number' => 1,
+            'duration_minutes' => 60,
+            'end_time' => '11:00',
         ]);
     }
 
@@ -58,6 +62,8 @@ class SurgeryRequestTest extends TestCase
             'date' => now()->addDay(),
             'start_time' => '10:00',
             'end_time' => '11:00',
+            'room_number' => 1,
+            'duration_minutes' => 60,
             'patient_name' => 'Alice',
             'procedure' => 'Proc1',
             'status' => 'requested',
@@ -68,6 +74,8 @@ class SurgeryRequestTest extends TestCase
             'date' => now()->addDays(2),
             'start_time' => '12:00',
             'end_time' => '13:00',
+            'room_number' => 2,
+            'duration_minutes' => 60,
             'patient_name' => 'Bob',
             'procedure' => 'Proc2',
             'status' => 'requested',
@@ -93,6 +101,8 @@ class SurgeryRequestTest extends TestCase
             'date' => now()->addDay(),
             'start_time' => '09:00',
             'end_time' => '10:00',
+            'room_number' => 1,
+            'duration_minutes' => 60,
             'patient_name' => 'Patient',
             'procedure' => 'Proc',
             'status' => 'requested',
@@ -130,6 +140,8 @@ class SurgeryRequestTest extends TestCase
             'date' => now()->addDay(),
             'start_time' => '09:00',
             'end_time' => '10:00',
+            'room_number' => 1,
+            'duration_minutes' => 60,
             'patient_name' => 'Patient',
             'procedure' => 'Proc',
             'status' => 'requested',
@@ -160,6 +172,8 @@ class SurgeryRequestTest extends TestCase
             'date' => now()->addDay(),
             'start_time' => '09:00',
             'end_time' => '10:00',
+            'room_number' => 1,
+            'duration_minutes' => 60,
             'patient_name' => 'Patient',
             'procedure' => 'Proc',
             'status' => 'requested',
@@ -167,7 +181,7 @@ class SurgeryRequestTest extends TestCase
         ]);
 
         $this->actingAs($nurse);
-        $controller = new SurgeryRequestController();
+        $controller = new SurgeryRequestController;
         $controller->reject($request, new HttpRequest(['reason' => 'No beds']));
 
         $this->assertEquals('rejected', $request->fresh()->status);


### PR DESCRIPTION
## Summary
- support room-specific scheduling by storing `room_number` and `duration_minutes`
- compute end times from duration and check overlaps per room
- add migration and tests for new scheduling fields

## Testing
- `php artisan test` (fails: Vite manifest missing, SQLite lacks FOR UPDATE)

------
https://chatgpt.com/codex/tasks/task_e_68aef03bdc0c832a8ef2bae4dccb79dc