### PR TITLE
Add surgery calendar with room-based availability

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\SurgeryRequest;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class CalendarController extends Controller
+{
+    public function index(Request $request)
+    {
+        if ($request->wantsJson() || $request->query('room_number')) {
+            $data = $request->validate([
+                'room_number' => ['required','integer','between:1,9'],
+                'start_date'  => ['required','date'],
+                'end_date'    => ['required','date','after_or_equal:start_date'],
+            ]);
+
+            $surgeries = SurgeryRequest::where('meta', 'like', '%"room_number":'.$data['room_number'].'%')
+                ->whereBetween('date', [$data['start_date'], $data['end_date']])
+                ->orderBy('date')
+                ->orderBy('start_time')
+                ->get(['id','date','start_time','end_time','patient_name','procedure']);
+
+            return response()->json($surgeries);
+        }
+
+        return Inertia::render('Calendar');
+    }
+}
+

--- a/resources/js/Pages/Calendar.vue
+++ b/resources/js/Pages/Calendar.vue
@@ -1,9 +1,48 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head } from '@inertiajs/vue3';
+import { ref, watch, computed } from 'vue';
+import axios from 'axios';
 
-const props = defineProps({
-    surgeries: Array,
+const roomNumber = ref(1);
+const today = new Date().toISOString().slice(0,10);
+const startDate = ref(today);
+const endDate = ref(today);
+const surgeries = ref([]);
+
+async function fetchSurgeries() {
+    const { data } = await axios.get('/calendar', {
+        params: {
+            room_number: roomNumber.value,
+            start_date: startDate.value,
+            end_date: endDate.value,
+        },
+    });
+    surgeries.value = data;
+}
+
+watch([roomNumber, startDate, endDate], fetchSurgeries, { immediate: true });
+
+const days = computed(() => {
+    const start = new Date(startDate.value);
+    const end = new Date(endDate.value);
+    const list = [];
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+        const dateStr = d.toISOString().slice(0, 10);
+        const slots = [];
+        for (let h = 8; h < 18; h++) {
+            const time = String(h).padStart(2, '0') + ':00';
+            const booked = surgeries.value.some(
+                (s) =>
+                    s.date === dateStr &&
+                    h >= parseInt(s.start_time.slice(0, 2)) &&
+                    h < parseInt(s.end_time.slice(0, 2))
+            );
+            slots.push({ time, booked });
+        }
+        list.push({ date: dateStr, slots });
+    }
+    return list;
 });
 </script>
 
@@ -16,9 +55,36 @@ const props = defineProps({
 
         <div class="py-12">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                    <div class="p-6 text-gray-900">
-                        <p>Visualize as cirurgias agendadas aqui.</p>
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6 text-gray-900">
+                    <div class="mb-4 flex gap-4">
+                        <div>
+                            <label class="block text-sm font-medium">Sala</label>
+                            <select v-model.number="roomNumber" class="border rounded p-1">
+                                <option v-for="n in 9" :key="n" :value="n">{{ n }}</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium">Início</label>
+                            <input type="date" v-model="startDate" class="border rounded p-1" />
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium">Fim</label>
+                            <input type="date" v-model="endDate" class="border rounded p-1" />
+                        </div>
+                    </div>
+
+                    <div v-for="day in days" :key="day.date" class="mb-6">
+                        <h3 class="font-semibold mb-2">{{ day.date }}</h3>
+                        <div class="grid grid-cols-10 gap-2">
+                            <div
+                                v-for="slot in day.slots"
+                                :key="slot.time"
+                                class="p-2 text-center text-xs"
+                                :class="slot.booked ? 'bg-red-500 text-white' : 'bg-green-200'"
+                            >
+                                {{ slot.time }}
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\ChecklistController;
 use App\Http\Controllers\DocumentController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Admin\UserController;
+use App\Http\Controllers\CalendarController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -48,9 +49,11 @@ Route::middleware(['auth','verified','role:enfermeiro'])
     ->get('/enfermeiro/dashboard',[DashboardController::class,'enfermeiro'])
     ->name('enfermeiro.dashboard');
 
+Route::middleware(['auth','role:medico|admin'])
+    ->get('/calendar',[CalendarController::class,'index'])
+    ->name('calendar');
+
 Route::middleware('auth')->group(function () {
-    Route::get('/calendar', fn () => Inertia::render('Calendar'))
-        ->name('calendar');
     // Perfil do usuário (Breeze)
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\SurgeryRequest;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class CalendarTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    public function test_doctor_can_fetch_room_surgeries(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        SurgeryRequest::create([
+            'doctor_id' => $doctor->id,
+            'date' => '2025-01-10',
+            'start_time' => '10:00',
+            'end_time' => '11:00',
+            'patient_name' => 'A',
+            'procedure' => 'Proc',
+            'status' => 'approved',
+            'meta' => ['room_number' => 1],
+        ]);
+        SurgeryRequest::create([
+            'doctor_id' => $doctor->id,
+            'date' => '2025-01-10',
+            'start_time' => '12:00',
+            'end_time' => '13:00',
+            'patient_name' => 'B',
+            'procedure' => 'Proc',
+            'status' => 'approved',
+            'meta' => ['room_number' => 2],
+        ]);
+
+        $response = $this->actingAs($doctor)->getJson('/calendar?room_number=1&start_date=2025-01-01&end_date=2025-01-31');
+
+        $response->assertStatus(200)->assertJsonCount(1)->assertJsonFragment(['patient_name' => 'A']);
+    }
+
+    public function test_non_doctor_cannot_access_calendar(): void
+    {
+        $user = User::factory()->create(); // no role
+
+        $response = $this->actingAs($user)->get('/calendar');
+        $response->assertStatus(403);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add CalendarController to serve surgeries for a given room and date range
- Replace /calendar route with authorized controller action
- Build interactive calendar view with room selector and availability highlighting
- Cover calendar data endpoint with feature tests

## Testing
- `composer install --ignore-platform-reqs`
- `vendor/bin/phpunit tests/Feature/CalendarTest.php`
- `vendor/bin/phpunit` *(fails: admin, auth, password reset, checklist, profile, surgery request tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aef03d5d5c832ab83189b44872032c