### PR TITLE
Allow filtering surgery requests by room

### DIFF
--- a/app/Http/Controllers/SurgeryRequestController.php
+++ b/app/Http/Controllers/SurgeryRequestController.php
@@ -32,13 +32,14 @@ class SurgeryRequestController extends Controller
         ]);
     }
 
-    // Lista geral (para enfermagem/admin) com filtro por status
+    // Lista geral (para enfermagem/admin) com filtro por status e sala
     public function index(Request $req)
     {
         $this->authorize('viewAny', SurgeryRequest::class);
 
         $q = SurgeryRequest::query()->with(['doctor','nurse'])
             ->when($req->status, fn($qq) => $qq->where('status', $req->status))
+            ->when($req->room_number, fn($qq) => $qq->where('room_number', $req->room_number))
             ->orderBy('date')->orderBy('start_time');
 
         $requests = $q->paginate(20);
@@ -49,7 +50,10 @@ class SurgeryRequestController extends Controller
 
         return inertia('Enfermeiro/Solicitacoes', [
             'requests' => $requests,
-            'filters'  => ['status' => $req->status]
+            'filters'  => [
+                'status' => $req->status,
+                'room_number' => $req->room_number,
+            ],
         ]);
     }
 

--- a/resources/js/Pages/Enfermeiro/Solicitacoes.vue
+++ b/resources/js/Pages/Enfermeiro/Solicitacoes.vue
@@ -1,11 +1,24 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head, router } from '@inertiajs/vue3';
+import { reactive } from 'vue';
 
 const props = defineProps({
     requests: Object,
     filters: Object,
 });
+
+const params = reactive({
+    status: props.filters.status || '',
+    room_number: props.filters.room_number || '',
+});
+
+function applyFilters() {
+    router.get(route('surgery-requests.index'), params, {
+        preserveState: true,
+        replace: true,
+    });
+}
 
 function cancel(id) {
     if (confirm('Cancelar esta solicitação?')) {
@@ -24,6 +37,25 @@ function cancel(id) {
         <div class="py-12">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                    <div class="mb-4 flex gap-4">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Status</label>
+                            <select v-model="params.status" @change="applyFilters" class="mt-1 block w-full border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm">
+                                <option value="">Todos</option>
+                                <option value="requested">Solicitado</option>
+                                <option value="approved">Aprovado</option>
+                                <option value="rejected">Rejeitado</option>
+                                <option value="cancelled">Cancelado</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Sala</label>
+                            <select v-model="params.room_number" @change="applyFilters" class="mt-1 block w-full border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm">
+                                <option value="">Todas</option>
+                                <option v-for="n in 9" :key="n" :value="n">{{ n }}</option>
+                            </select>
+                        </div>
+                    </div>
                     <table class="min-w-full divide-y divide-gray-200">
                         <thead>
                             <tr>

--- a/tests/Feature/SurgeryRequestTest.php
+++ b/tests/Feature/SurgeryRequestTest.php
@@ -176,4 +176,46 @@ class SurgeryRequestTest extends TestCase
         $this->assertEquals($nurse->id, $request->fresh()->nurse_id);
         $this->assertEquals('No beds', $request->fresh()->meta['reject_reason']);
     }
+
+    public function test_index_can_filter_by_room_number(): void
+    {
+        $this->withoutVite();
+
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+        $nurse = User::factory()->create();
+        $nurse->assignRole('enfermeiro');
+
+        SurgeryRequest::create([
+            'doctor_id' => $doctor->id,
+            'date' => now()->addDay(),
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'room_number' => 1,
+            'duration_minutes' => 60,
+            'patient_name' => 'Alice',
+            'procedure' => 'Proc1',
+            'status' => 'requested',
+            'meta' => [],
+        ]);
+
+        SurgeryRequest::create([
+            'doctor_id' => $doctor->id,
+            'date' => now()->addDays(2),
+            'start_time' => '11:00',
+            'end_time' => '12:00',
+            'room_number' => 2,
+            'duration_minutes' => 60,
+            'patient_name' => 'Bob',
+            'procedure' => 'Proc2',
+            'status' => 'requested',
+            'meta' => [],
+        ]);
+
+        $response = $this->actingAs($nurse)->get('/surgery-requests?room_number=1');
+
+        $response->assertStatus(200);
+        $response->assertSee('Alice');
+        $response->assertDontSee('Bob');
+    }
 }


### PR DESCRIPTION
## Summary
- Support optional `room_number` query parameter in surgery request index
- Add room & status filters to nurse/admin request listing
- Test filtering requests by room number

## Testing
- `php artisan test --filter index_can_filter_by_room_number`
- `php artisan test` *(fails: NOT NULL constraint failed: surgery_requests.room_number)*

------
https://chatgpt.com/codex/tasks/task_e_68af51122e74832a8deac24ed65600e8