### PR TITLE
Migrate room and duration from meta

### DIFF
--- a/app/Models/SurgeryRequest.php
+++ b/app/Models/SurgeryRequest.php
@@ -3,19 +3,19 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use App\Models\Document;
 
 class SurgeryRequest extends Model
 {
     protected $fillable = [
-        'doctor_id','nurse_id','date','start_time','end_time',
-        'room_number','duration_minutes',
-        'patient_name','procedure','status','meta'
+        'doctor_id', 'nurse_id', 'date', 'start_time', 'end_time',
+        'room_number', 'duration_minutes',
+        'patient_name', 'procedure', 'status', 'meta',
     ];
 
     protected $casts = [
         'date' => 'date',
         'meta' => 'array',
+        'room_number' => 'integer',
         'duration_minutes' => 'integer',
     ];
 

--- a/database/migrations/2025_08_25_174800_migrate_room_and_duration_from_meta.php
+++ b/database/migrations/2025_08_25_174800_migrate_room_and_duration_from_meta.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Models\SurgeryRequest;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        SurgeryRequest::cursor()->each(function (SurgeryRequest $request) {
+            $meta = $request->meta ?? [];
+            $updates = [];
+
+            if (isset($meta['room'])) {
+                $updates['room_number'] = $meta['room'];
+                unset($meta['room']);
+            }
+
+            if (isset($meta['duration'])) {
+                $updates['duration_minutes'] = $meta['duration'];
+                unset($meta['duration']);
+            }
+
+            if ($updates) {
+                $updates['meta'] = $meta ?: null;
+                $request->update($updates);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        SurgeryRequest::cursor()->each(function (SurgeryRequest $request) {
+            $meta = $request->meta ?? [];
+
+            if ($request->room_number !== null) {
+                $meta['room'] = $request->room_number;
+            }
+
+            if ($request->duration_minutes !== null) {
+                $meta['duration'] = $request->duration_minutes;
+            }
+
+            $request->update([
+                'meta' => $meta,
+                'room_number' => null,
+                'duration_minutes' => null,
+            ]);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- migrate existing `room` and `duration` values from `meta` into dedicated `room_number` and `duration_minutes` columns
- cast `room_number` as integer and streamline request handling to use validated data

## Testing
- `php artisan test` *(fails: file_get_contents(/workspace/cirurgias/.env): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af58fc2168832a957572bef030f409