### PR TITLE
Add room filter for surgery request listing

### DIFF
--- a/resources/js/Pages/Enfermeiro/Solicitacoes.vue
+++ b/resources/js/Pages/Enfermeiro/Solicitacoes.vue
@@ -1,11 +1,24 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head, router } from '@inertiajs/vue3';
+import { reactive } from 'vue';
 
 const props = defineProps({
     requests: Object,
     filters: Object,
 });
+
+const filterForm = reactive({
+    status: props.filters.status || '',
+    room: props.filters.room || '',
+});
+
+function applyFilters() {
+    router.get(route('surgery-requests.index'), filterForm, {
+        preserveState: true,
+        replace: true,
+    });
+}
 
 function cancel(id) {
     if (confirm('Cancelar esta solicitação?')) {
@@ -24,6 +37,21 @@ function cancel(id) {
         <div class="py-12">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                    <form @submit.prevent="applyFilters" class="mb-4 flex space-x-2">
+                        <input
+                            type="text"
+                            v-model="filterForm.room"
+                            placeholder="Sala"
+                            class="border rounded px-2 py-1"
+                        />
+                        <select v-model="filterForm.status" class="border rounded px-2 py-1">
+                            <option value="">Todos</option>
+                            <option value="requested">Solicitado</option>
+                            <option value="approved">Aprovado</option>
+                            <option value="rejected">Rejeitado</option>
+                        </select>
+                        <button type="submit" class="px-3 py-1 bg-blue-600 text-white rounded">Filtrar</button>
+                    </form>
                     <table class="min-w-full divide-y divide-gray-200">
                         <thead>
                             <tr>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -12,7 +12,9 @@
 
         <!-- Scripts -->
         @routes
-        @vite(['resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])
+        @unless(app()->environment('testing'))
+            @vite(['resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])
+        @endunless
         @inertiaHead
     </head>
     <body class="font-sans antialiased">

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,20 +80,20 @@ Route::middleware('auth')->group(function () {
             ->name('surgery-requests.indexMy');
 
         // cancelar/remover pedido
-        Route::delete('/surgery-requests/{request}', [SurgeryRequestController::class, 'destroy'])
+        Route::delete('/surgery-requests/{surgeryRequest}', [SurgeryRequestController::class, 'destroy'])
             ->name('surgery-requests.destroy');
     });
 
     // edição/atualização do pedido
     Route::middleware(['role:medico|enfermeiro|admin'])->group(function () {
-        Route::get('/surgery-requests/{request}/edit', [SurgeryRequestController::class, 'edit'])
+        Route::get('/surgery-requests/{surgeryRequest}/edit', [SurgeryRequestController::class, 'edit'])
             ->name('surgery-requests.edit');
-        Route::match(['put', 'patch'], '/surgery-requests/{request}', [SurgeryRequestController::class, 'update'])
+        Route::match(['put', 'patch'], '/surgery-requests/{surgeryRequest}', [SurgeryRequestController::class, 'update'])
             ->name('surgery-requests.update');
 
-        Route::post('/surgery-requests/{request}/documents', [DocumentController::class, 'store'])
+        Route::post('/surgery-requests/{surgeryRequest}/documents', [DocumentController::class, 'store'])
             ->name('surgery-requests.documents.store');
-        Route::delete('/surgery-requests/{request}/documents/{document}', [DocumentController::class, 'destroy'])
+        Route::delete('/surgery-requests/{surgeryRequest}/documents/{document}', [DocumentController::class, 'destroy'])
             ->name('surgery-requests.documents.destroy');
     });
 
@@ -112,13 +112,13 @@ Route::middleware('auth')->group(function () {
             ->name('surgery-requests.index');
 
         // marcar item do checklist (autorização via Policy do pedido pai)
-        Route::put('/surgery-requests/{request}/checklist-items/{item}', [SurgeryRequestController::class, 'updateChecklistItem'])
+        Route::put('/surgery-requests/{surgeryRequest}/checklist-items/{item}', [SurgeryRequestController::class, 'updateChecklistItem'])
             ->name('surgery-requests.checklist-items.update');
 
         // aprovar / reprovar
-        Route::post('/surgery-requests/{request}/approve', [SurgeryRequestController::class, 'approve'])
+        Route::post('/surgery-requests/{surgeryRequest}/approve', [SurgeryRequestController::class, 'approve'])
             ->name('surgery-requests.approve');
-        Route::post('/surgery-requests/{request}/reject', [SurgeryRequestController::class, 'reject'])
+        Route::post('/surgery-requests/{surgeryRequest}/reject', [SurgeryRequestController::class, 'reject'])
             ->name('surgery-requests.reject');
 
         // CRUD de checklists (modelos)

--- a/tests/Feature/SurgeryRequestTest.php
+++ b/tests/Feature/SurgeryRequestTest.php
@@ -87,6 +87,46 @@ class SurgeryRequestTest extends TestCase
         $response->assertDontSee('Bob');
     }
 
+    public function test_nurse_filters_requests_by_room(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+        $nurse = User::factory()->create();
+        $nurse->assignRole('enfermeiro');
+
+        SurgeryRequest::create([
+            'doctor_id'        => $doctor->id,
+            'date'             => now()->addDay(),
+            'start_time'       => '08:00',
+            'end_time'         => '09:00',
+            'room_number'      => 1,
+            'duration_minutes' => 60,
+            'patient_name'     => 'Alice',
+            'procedure'        => 'Proc1',
+            'status'           => 'requested',
+            'meta'             => [],
+        ]);
+
+        SurgeryRequest::create([
+            'doctor_id'        => $doctor->id,
+            'date'             => now()->addDay(),
+            'start_time'       => '10:00',
+            'end_time'         => '11:00',
+            'room_number'      => 2,
+            'duration_minutes' => 60,
+            'patient_name'     => 'Bob',
+            'procedure'        => 'Proc2',
+            'status'           => 'requested',
+            'meta'             => [],
+        ]);
+
+        $response = $this->actingAs($nurse)->get('/surgery-requests?room=1');
+
+        $response->assertStatus(200);
+        $response->assertSee('Alice');
+        $response->assertDontSee('Bob');
+    }
+
     public function test_nurse_can_update_checklist_item(): void
     {
         $doctor = User::factory()->create();


### PR DESCRIPTION
## Summary
- filter surgery requests by room in index view
- add room/status filter form to nurse requests page
- adjust routes and policies for updated parameter names
- skip Vite asset loading during tests
- cover room filtering with new feature test

## Testing
- `php artisan test --filter=SurgeryRequestTest`
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: ExampleTest and auth tests due to environment)*


------
https://chatgpt.com/codex/tasks/task_e_68af5f6fc398832ab06582a4b91718a7