### PR TITLE
test: cover room overlaps and metadata

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -21,7 +21,7 @@ class CalendarController extends Controller
                 ->whereBetween('date', [$data['start_date'], $data['end_date']])
                 ->orderBy('date')
                 ->orderBy('start_time')
-                ->get(['id','date','start_time','end_time','patient_name','procedure']);
+                ->get(['id','date','start_time','end_time','patient_name','procedure','room_number','duration_minutes']);
 
             return response()->json($surgeries);
         }

--- a/app/Http/Controllers/SurgeryRequestController.php
+++ b/app/Http/Controllers/SurgeryRequestController.php
@@ -90,8 +90,9 @@ class SurgeryRequestController extends Controller
                 DB::select('SELECT id FROM surgery_requests WHERE date = ? FOR UPDATE', [$date]);
             }
 
-            // 2) Checagem de sobreposição (global)
+            // 2) Checagem de sobreposição (por sala)
             $conflict = SurgeryRequest::where('date', $date)
+                ->where('room_number', $data['room_number'])
                 ->whereIn('status', ['requested', 'approved'])
                 ->where('start_time', '<', $end)
                 ->where('end_time', '>', $start)
@@ -153,6 +154,7 @@ class SurgeryRequestController extends Controller
 
             $conflict = SurgeryRequest::where('date', $date)
                 ->where('id', '!=', $surgeryRequest->id)
+                ->where('room_number', $data['room_number'])
                 ->whereIn('status', ['requested', 'approved'])
                 ->where('start_time', '<', $end)
                 ->where('end_time', '>', $start)
@@ -230,6 +232,7 @@ class SurgeryRequestController extends Controller
 
             $conflict = SurgeryRequest::where('date', $surgeryRequest->date)
                 ->where('id', '!=', $surgeryRequest->id)
+                ->where('room_number', $surgeryRequest->room_number)
                 ->whereIn('status', ['approved'])
                 ->where('start_time', '<', $surgeryRequest->end_time)
                 ->where('end_time', '>', $surgeryRequest->start_time)

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -50,7 +50,13 @@ class CalendarTest extends TestCase
 
         $response = $this->actingAs($doctor)->getJson('/calendar?room_number=1&start_date=2025-01-01&end_date=2025-01-31');
 
-        $response->assertStatus(200)->assertJsonCount(1)->assertJsonFragment(['patient_name' => 'A']);
+        $response->assertStatus(200)
+            ->assertJsonCount(1)
+            ->assertJsonFragment([
+                'patient_name' => 'A',
+                'room_number' => 1,
+                'duration_minutes' => 60,
+            ]);
     }
 
     public function test_non_doctor_cannot_access_calendar(): void

--- a/tests/Feature/DocumentTest.php
+++ b/tests/Feature/DocumentTest.php
@@ -29,6 +29,8 @@ class DocumentTest extends TestCase
             'date' => now()->addDay(),
             'start_time' => '09:00',
             'end_time' => '10:00',
+            'room_number' => 1,
+            'duration_minutes' => 60,
             'patient_name' => 'Patient',
             'procedure' => 'Proc',
             'status' => 'requested',


### PR DESCRIPTION
## Summary
- add room-aware overlap checks for surgery requests
- expose room_number and duration_minutes in calendar data
- extend feature tests for room and duration handling

## Testing
- `vendor/bin/phpunit tests/Feature/CalendarTest.php tests/Feature/SurgeryRequestTest.php tests/Feature/DocumentTest.php` *(fails: Tests\Feature\SurgeryRequestTest::test_rejects_overlapping_surgeries_in_same_room)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f41d774832aa7eb5044656d1dac