### PR TITLE
Expose room and duration fields

### DIFF
--- a/app/Http/Controllers/SurgeryRequestController.php
+++ b/app/Http/Controllers/SurgeryRequestController.php
@@ -23,9 +23,22 @@ class SurgeryRequestController extends Controller
             ->paginate(15);
 
         $data->getCollection()->transform(function ($r) {
-            $r->can_cancel = Auth::user()->can('delete', $r) || Auth::user()->can('update', $r);
-
-            return $r;
+            return array_merge(
+                $r->only([
+                    'id',
+                    'date',
+                    'start_time',
+                    'end_time',
+                    'room_number',
+                    'duration_minutes',
+                    'patient_name',
+                    'procedure',
+                    'status',
+                ]),
+                [
+                    'can_cancel' => Auth::user()->can('delete', $r) || Auth::user()->can('update', $r),
+                ]
+            );
         });
 
         return inertia('Medico/MinhasSolicitacoes', [
@@ -45,9 +58,22 @@ class SurgeryRequestController extends Controller
 
         $requests = $q->paginate(20);
         $requests->getCollection()->transform(function ($r) {
-            $r->can_cancel = Auth::user()->can('delete', $r) || Auth::user()->can('update', $r);
-
-            return $r;
+            return array_merge(
+                $r->only([
+                    'id',
+                    'date',
+                    'start_time',
+                    'end_time',
+                    'room_number',
+                    'duration_minutes',
+                    'patient_name',
+                    'procedure',
+                    'status',
+                ]),
+                [
+                    'can_cancel' => Auth::user()->can('delete', $r) || Auth::user()->can('update', $r),
+                ]
+            );
         });
 
         return inertia('Enfermeiro/Solicitacoes', [
@@ -70,7 +96,18 @@ class SurgeryRequestController extends Controller
         $this->authorize('update', $surgeryRequest);
 
         return inertia('Medico/NovaSolicitacao', [
-            'request' => $surgeryRequest,
+            'request' => $surgeryRequest->only([
+                'id',
+                'date',
+                'start_time',
+                'end_time',
+                'room_number',
+                'duration_minutes',
+                'patient_name',
+                'procedure',
+                'status',
+                'meta',
+            ]),
         ]);
     }
 

--- a/resources/js/Pages/Medico/NovaSolicitacao.vue
+++ b/resources/js/Pages/Medico/NovaSolicitacao.vue
@@ -9,18 +9,23 @@ import { Head, useForm } from '@inertiajs/vue3';
 import { computed } from 'vue';
 
 const props = defineProps({
-    request: Object,
+    request: {
+        type: Object,
+        default: null,
+    },
 });
 
+const req = props.request ?? {};
+
 const form = useForm({
-    date: props.request?.date ?? '',
-    start_time: props.request?.start_time ?? '',
-    end_time: props.request?.end_time ?? '',
-    duration_minutes: props.request?.duration_minutes ?? '',
-    room_number: props.request?.room_number ?? '',
-    patient_name: props.request?.patient_name ?? '',
-    procedure: props.request?.procedure ?? '',
-    confirm_docs: props.request?.meta?.confirm_docs ?? false,
+    date: req.date ?? '',
+    start_time: req.start_time ?? '',
+    end_time: req.end_time ?? '',
+    duration_minutes: req.duration_minutes ?? '',
+    room_number: req.room_number ?? '',
+    patient_name: req.patient_name ?? '',
+    procedure: req.procedure ?? '',
+    confirm_docs: req.meta?.confirm_docs ?? false,
 });
 
 const isApproved = computed(() => props.request?.status === 'approved');


### PR DESCRIPTION
## Summary
- expose `room_number` and `duration_minutes` in surgery request responses
- read these fields from top-level props in the request form component

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0; current php is 8.4.11)*


------
https://chatgpt.com/codex/tasks/task_e_68b03f431d44832a94ee842c95761d50