### PR TITLE
docs: document room-based scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,32 @@ This command creates an admin user with:
 
 Use these credentials to log in.
 
+## Room-Based Scheduling
+
+Surgery requests now require a **room number** indicating where the procedure will take place.
+Rooms are numbered from 1 to 9 and the selected room is stored with each request.
+
+### Validation rules
+
+When creating or updating a surgery request the following rules apply:
+
+- `room_number` must be an integer between 1 and 9.
+- `duration_minutes` must be a positive integer.
+- `date` cannot be in the past and `end_time` must be after `start_time`.
+
+If an existing surgery overlaps the same time range (even in a different room) the request is
+rejected with a validation error mentioning the conflicting room and times.
+
+### Querying the calendar by room
+
+Doctors and admins can fetch the schedule for a specific room via the calendar endpoint:
+
+```bash
+GET /calendar?room_number=2&start_date=2025-01-01&end_date=2025-01-31
+```
+
+The endpoint returns the surgeries scheduled for that room and date range as JSON.
+
 ## Learning Laravel
 
 Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -1,0 +1,16 @@
+# Calendar API
+
+The calendar endpoint lets doctors and admins query surgeries scheduled in a specific room.
+
+```bash
+GET /calendar?room_number=1&start_date=2025-01-01&end_date=2025-01-31
+```
+
+Parameters:
+- `room_number`: required integer between 1 and 9.
+- `start_date` and `end_date`: required dates (end must be on or after start).
+
+The response is JSON ordered by date and start time and includes the `id`, `date`, `start_time`, `end_time`, `patient_name`, and `procedure` fields.
+
+When submitting surgery requests, the same room and date rules are validated and any overlapping schedule—regardless of room—triggers a validation error describing the conflicting room and times.
+


### PR DESCRIPTION
## Summary
- document required room numbers and validation rules
- show how to query calendar schedules by room

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0, current 8.4.11)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f44b184832a9416a4eee354a180