### PR TITLE
Use duration to block calendar slots

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -21,7 +21,7 @@ class CalendarController extends Controller
                 ->whereBetween('date', [$data['start_date'], $data['end_date']])
                 ->orderBy('date')
                 ->orderBy('start_time')
-                ->get(['id','date','start_time','end_time','patient_name','procedure']);
+                ->get(['id','date','start_time','end_time','duration_minutes','patient_name','procedure']);
 
             return response()->json($surgeries);
         }

--- a/resources/js/Pages/Calendar.vue
+++ b/resources/js/Pages/Calendar.vue
@@ -32,12 +32,15 @@ const days = computed(() => {
         const slots = [];
         for (let h = 8; h < 18; h++) {
             const time = String(h).padStart(2, '0') + ':00';
-            const booked = surgeries.value.some(
-                (s) =>
-                    s.date === dateStr &&
-                    h >= parseInt(s.start_time.slice(0, 2)) &&
-                    h < parseInt(s.end_time.slice(0, 2))
-            );
+            const slotStart = h * 60;
+            const slotEnd = slotStart + 60;
+            const booked = surgeries.value.some((s) => {
+                if (s.date !== dateStr) return false;
+                const [startHour, startMinute] = s.start_time.split(':').map(Number);
+                const surgeryStart = startHour * 60 + startMinute;
+                const surgeryEnd = surgeryStart + s.duration_minutes;
+                return slotStart < surgeryEnd && slotEnd > surgeryStart;
+            });
             slots.push({ time, booked });
         }
         list.push({ date: dateStr, slots });

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -50,7 +50,9 @@ class CalendarTest extends TestCase
 
         $response = $this->actingAs($doctor)->getJson('/calendar?room_number=1&start_date=2025-01-01&end_date=2025-01-31');
 
-        $response->assertStatus(200)->assertJsonCount(1)->assertJsonFragment(['patient_name' => 'A']);
+        $response->assertStatus(200)
+            ->assertJsonCount(1)
+            ->assertJsonFragment(['patient_name' => 'A', 'duration_minutes' => 60]);
     }
 
     public function test_non_doctor_cannot_access_calendar(): void


### PR DESCRIPTION
## Summary
- mark calendar hours as booked when they overlap a surgery's start time and duration
- expose `duration_minutes` in calendar API
- verify API response includes surgery duration

## Testing
- `/root/.local/share/mise/installs/php/8.3.24/bin/php artisan test` *(fails: 9 failed, 2 warnings, 1 skipped, 34 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f4709e8832ab4ebd022e4358bfe