### PR TITLE
test: verify automatic end_time calculation

### DIFF
--- a/app/Http/Requests/StoreSurgeryRequestRequest.php
+++ b/app/Http/Requests/StoreSurgeryRequestRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Carbon;
 
 class StoreSurgeryRequestRequest extends FormRequest
 {
@@ -10,6 +11,16 @@ class StoreSurgeryRequestRequest extends FormRequest
     {
         // Policy vai validar depois; aqui pode liberar.
         return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if (!$this->input('end_time') && $this->input('start_time') && $this->input('duration_minutes')) {
+            $end = Carbon::createFromFormat('H:i', $this->input('start_time'))
+                ->addMinutes((int) $this->input('duration_minutes'))
+                ->format('H:i');
+            $this->merge(['end_time' => $end]);
+        }
     }
 
     public function rules(): array

--- a/tests/Feature/SurgeryRequestTest.php
+++ b/tests/Feature/SurgeryRequestTest.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Spatie\Permission\PermissionRegistrar;
 use App\Http\Controllers\SurgeryRequestController;
 use Illuminate\Http\Request as HttpRequest;
+use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 class SurgeryRequestTest extends TestCase
@@ -46,6 +47,28 @@ class SurgeryRequestTest extends TestCase
             'patient_name' => 'John Doe',
             'status' => 'requested',
         ]);
+    }
+
+    public function test_end_time_is_calculated_when_missing(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $payload = [
+            'date' => now()->addDay()->toDateString(),
+            'start_time' => '10:00',
+            'duration_minutes' => 90,
+            'room_number' => 1,
+            'patient_name' => 'Jane Doe',
+            'procedure' => 'Appendectomy',
+        ];
+
+        $response = $this->actingAs($doctor)->post('/surgery-requests', $payload);
+
+        $response->assertRedirect();
+        $request = SurgeryRequest::first();
+        $expected = Carbon::createFromFormat('H:i', '10:00')->addMinutes(90)->format('H:i');
+        $this->assertEquals($expected, substr($request->end_time, 0, 5));
     }
 
     public function test_doctor_lists_only_their_requests(): void


### PR DESCRIPTION
## Summary
- compute end_time from start_time and duration when client omits it
- cover missing end_time scenario with feature test

## Testing
- `vendor/bin/phpunit tests/Feature/SurgeryRequestTest.php`
- `vendor/bin/phpunit` *(fails: Tests\Feature\Auth\PasswordResetTest::test_password_can_be_reset_with_valid_token, Tests\Feature\Auth\PasswordResetTest::test_password_can_be_reset_with_valid_token, Tests\Feature\ExampleTest::test_the_application_returns_a_successful_response)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f4aad60832a9355b498fe7eeaf7