### PR TITLE
Allow nurses to access calendar

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -49,7 +49,7 @@ Route::middleware(['auth','verified','role:enfermeiro'])
     ->get('/enfermeiro/dashboard',[DashboardController::class,'enfermeiro'])
     ->name('enfermeiro.dashboard');
 
-Route::middleware(['auth','role:medico|admin'])
+Route::middleware(['auth','role:medico|enfermeiro|admin'])
     ->get('/calendar',[CalendarController::class,'index'])
     ->name('calendar');
 

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -53,7 +53,16 @@ class CalendarTest extends TestCase
         $response->assertStatus(200)->assertJsonCount(1)->assertJsonFragment(['patient_name' => 'A']);
     }
 
-    public function test_non_doctor_cannot_access_calendar(): void
+    public function test_nurse_can_access_calendar(): void
+    {
+        $nurse = User::factory()->create();
+        $nurse->assignRole('enfermeiro');
+
+        $response = $this->actingAs($nurse)->get('/calendar');
+        $response->assertStatus(200);
+    }
+
+    public function test_user_without_role_cannot_access_calendar(): void
     {
         $user = User::factory()->create(); // no role
 


### PR DESCRIPTION
## Summary
- permit nurses to access calendar by extending route middleware
- test nurse access and ensure unauthorized users are blocked

## Testing
- `./vendor/bin/phpunit` *(fails: PasswordResetTest and ExampleTest failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f4be6b0832a9fcbced3a365ca10