### PR TITLE
Add DayReservation policy and authorization check

### DIFF
--- a/app/Http/Controllers/DayReservationController.php
+++ b/app/Http/Controllers/DayReservationController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\DayReservation;
+
+class DayReservationController extends Controller
+{
+    public function confirm(DayReservation $reservation)
+    {
+        $this->authorize('confirm', $reservation);
+
+        $reservation->update(['confirmed' => true]);
+
+        return back()->with('ok', 'Reserva confirmada.');
+    }
+
+    public function destroy(DayReservation $reservation)
+    {
+        $this->authorize('destroy', $reservation);
+
+        $reservation->delete();
+
+        return back()->with('ok', 'Reserva desmarcada.');
+    }
+}
+

--- a/app/Models/DayReservation.php
+++ b/app/Models/DayReservation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DayReservation extends Model
+{
+    protected $guarded = [];
+}
+

--- a/app/Policies/DayReservationPolicy.php
+++ b/app/Policies/DayReservationPolicy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\DayReservation;
+use App\Models\User;
+
+class DayReservationPolicy
+{
+    public function destroy(User $u, DayReservation $r): bool
+    {
+        return $u->hasAnyRole(['admin','enfermeiro']);
+    }
+
+    public function confirm(User $u, DayReservation $r): bool
+    {
+        return $u->hasAnyRole(['admin','enfermeiro']);
+    }
+}
+

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,16 +3,19 @@
 namespace App\Providers;
 
 use App\Models\Checklist;
+use App\Models\DayReservation;
 use App\Models\SurgeryRequest;
 use App\Policies\ChecklistPolicy;
+use App\Policies\DayReservationPolicy;
 use App\Policies\SurgeryRequestPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
 {
     protected $policies = [
-        SurgeryRequest::class => SurgeryRequestPolicy::class,
-        Checklist::class      => ChecklistPolicy::class,
+        SurgeryRequest::class  => SurgeryRequestPolicy::class,
+        Checklist::class       => ChecklistPolicy::class,
+        DayReservation::class  => DayReservationPolicy::class,
     ];
 
     public function boot(): void


### PR DESCRIPTION
## Summary
- add DayReservation policy with confirm and destroy abilities
- register DayReservation policy in AuthServiceProvider
- add DayReservation controller with authorization calls

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel requires php ~8.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b04f71d4a8832aabf58efa72a6b249