### PR TITLE
Add DayReservation policy and authorization tests

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -32,6 +32,8 @@ class CalendarController extends Controller
 
     public function store(Request $request)
     {
+        $this->authorize('create', DayReservation::class);
+
         $data = $request->validate([
             'date' => ['required', 'date'],
         ]);
@@ -47,6 +49,8 @@ class CalendarController extends Controller
 
     public function confirm(DayReservation $dayReservation)
     {
+        $this->authorize('confirm', $dayReservation);
+
         $dayReservation->update(['status' => 'confirmed']);
 
         return response()->json($dayReservation);
@@ -54,6 +58,8 @@ class CalendarController extends Controller
 
     public function destroy(DayReservation $dayReservation)
     {
+        $this->authorize('delete', $dayReservation);
+
         $dayReservation->delete();
 
         return response()->noContent();

--- a/app/Policies/DayReservationPolicy.php
+++ b/app/Policies/DayReservationPolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\DayReservation;
+use App\Models\User;
+
+class DayReservationPolicy
+{
+    public function create(User $user): bool
+    {
+        return $user->hasRole('medico');
+    }
+
+    public function confirm(User $user, DayReservation $reservation): bool
+    {
+        return $user->hasAnyRole(['enfermeiro', 'admin']);
+    }
+
+    public function delete(User $user, DayReservation $reservation): bool
+    {
+        return $user->hasRole('medico') && $reservation->doctor_id === $user->id;
+    }
+}
+

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,15 +4,18 @@ namespace App\Providers;
 
 use App\Models\Checklist;
 use App\Models\SurgeryRequest;
+use App\Models\DayReservation;
 use App\Policies\ChecklistPolicy;
 use App\Policies\SurgeryRequestPolicy;
+use App\Policies\DayReservationPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
 {
     protected $policies = [
-        SurgeryRequest::class => SurgeryRequestPolicy::class,
-        Checklist::class      => ChecklistPolicy::class,
+        SurgeryRequest::class  => SurgeryRequestPolicy::class,
+        Checklist::class       => ChecklistPolicy::class,
+        DayReservation::class  => DayReservationPolicy::class,
     ];
 
     public function boot(): void

--- a/tests/Feature/DayReservationPolicyTest.php
+++ b/tests/Feature/DayReservationPolicyTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\DayReservation;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class DayReservationPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    public function test_doctor_can_create_day_reservation(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $payload = ['date' => now()->addDay()->toDateString()];
+
+        $response = $this->actingAs($doctor)->postJson('/calendar', $payload);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('day_reservations', [
+            'doctor_id' => $doctor->id,
+        ]);
+    }
+
+    public function test_nurse_cannot_create_day_reservation(): void
+    {
+        $nurse = User::factory()->create();
+        $nurse->assignRole('enfermeiro');
+
+        $payload = ['date' => now()->addDay()->toDateString()];
+
+        $this->actingAs($nurse)->postJson('/calendar', $payload)
+            ->assertForbidden();
+    }
+
+    public function test_nurse_can_confirm_day_reservation(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+        $nurse = User::factory()->create();
+        $nurse->assignRole('enfermeiro');
+
+        $reservation = DayReservation::create([
+            'doctor_id' => $doctor->id,
+            'date' => now()->addDay(),
+            'status' => 'pending',
+        ]);
+
+        $this->actingAs($nurse)->postJson("/calendar/{$reservation->id}/confirm")
+            ->assertOk();
+
+        $this->assertDatabaseHas('day_reservations', [
+            'id' => $reservation->id,
+            'status' => 'confirmed',
+        ]);
+    }
+
+    public function test_admin_can_confirm_day_reservation(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
+        $reservation = DayReservation::create([
+            'doctor_id' => $doctor->id,
+            'date' => now()->addDay(),
+            'status' => 'pending',
+        ]);
+
+        $this->actingAs($admin)->postJson("/calendar/{$reservation->id}/confirm")
+            ->assertOk();
+
+        $this->assertDatabaseHas('day_reservations', [
+            'id' => $reservation->id,
+            'status' => 'confirmed',
+        ]);
+    }
+
+    public function test_doctor_cannot_confirm_day_reservation(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $reservation = DayReservation::create([
+            'doctor_id' => $doctor->id,
+            'date' => now()->addDay(),
+            'status' => 'pending',
+        ]);
+
+        $this->actingAs($doctor)->postJson("/calendar/{$reservation->id}/confirm")
+            ->assertForbidden();
+    }
+
+    public function test_doctor_can_delete_own_day_reservation(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $reservation = DayReservation::create([
+            'doctor_id' => $doctor->id,
+            'date' => now()->addDay(),
+            'status' => 'pending',
+        ]);
+
+        $this->actingAs($doctor)->deleteJson("/calendar/{$reservation->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('day_reservations', [
+            'id' => $reservation->id,
+        ]);
+    }
+
+    public function test_nurse_cannot_delete_day_reservation(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+        $nurse = User::factory()->create();
+        $nurse->assignRole('enfermeiro');
+
+        $reservation = DayReservation::create([
+            'doctor_id' => $doctor->id,
+            'date' => now()->addDay(),
+            'status' => 'pending',
+        ]);
+
+        $this->actingAs($nurse)->deleteJson("/calendar/{$reservation->id}")
+            ->assertForbidden();
+    }
+
+    public function test_admin_cannot_delete_day_reservation(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
+        $reservation = DayReservation::create([
+            'doctor_id' => $doctor->id,
+            'date' => now()->addDay(),
+            'status' => 'pending',
+        ]);
+
+        $this->actingAs($admin)->deleteJson("/calendar/{$reservation->id}")
+            ->assertForbidden();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add policy for day reservations with role checks
- register day reservation policy in auth provider
- enforce authorization in calendar controller
- add feature tests for day reservation authorization

## Testing
- `composer install --ignore-platform-reqs`
- `php artisan test` *(fails: Tests\Feature\SurgeryRequestTest > rejects overlapping surgeries in same room)*
- `php artisan test tests/Feature/DayReservationPolicyTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68b053ceb608832a8395e4c800453094