### PR TITLE
Use injected model for checklist query in approval

### DIFF
--- a/app/Http/Controllers/SurgeryRequestController.php
+++ b/app/Http/Controllers/SurgeryRequestController.php
@@ -254,7 +254,7 @@ class SurgeryRequestController extends Controller
 
         $hasItems = $surgeryRequest->checklistItems()->exists();
         if ($hasItems) {
-            $unchecked = $requestModel->checklistItems()->where('checked', false)->count();
+            $unchecked = $surgeryRequest->checklistItems()->where('checked', false)->count();
             if ($unchecked > 0) {
                 throw ValidationException::withMessages([
                     'checklist' => 'Existem itens do checklist ainda não marcados.',


### PR DESCRIPTION
## Summary
- fix SurgeryRequestController approve method to query checklist items from injected model

## Testing
- `php artisan test` *(fails: The user is not authenticated, expected 404 vs 200, missing .env, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b056826b98832a8c260b6534f5680a