### PR TITLE
Allow admins to delete day reservations

### DIFF
--- a/app/Policies/DayReservationPolicy.php
+++ b/app/Policies/DayReservationPolicy.php
@@ -19,7 +19,9 @@ class DayReservationPolicy
 
     public function delete(User $user, DayReservation $reservation): bool
     {
-        return $user->hasRole('medico') && $reservation->doctor_id === $user->id;
+        return $user->hasRole('admin') || (
+            $user->hasRole('medico') && $reservation->doctor_id === $user->id
+        );
     }
 }
 

--- a/tests/Feature/DayReservationPolicyTest.php
+++ b/tests/Feature/DayReservationPolicyTest.php
@@ -141,7 +141,7 @@ class DayReservationPolicyTest extends TestCase
             ->assertForbidden();
     }
 
-    public function test_admin_cannot_delete_day_reservation(): void
+    public function test_admin_can_delete_day_reservation(): void
     {
         $doctor = User::factory()->create();
         $doctor->assignRole('medico');
@@ -155,7 +155,11 @@ class DayReservationPolicyTest extends TestCase
         ]);
 
         $this->actingAs($admin)->deleteJson("/calendar/{$reservation->id}")
-            ->assertForbidden();
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('day_reservations', [
+            'id' => $reservation->id,
+        ]);
     }
 }
 


### PR DESCRIPTION
## Summary
- Permit admins to delete day reservations in policy
- Cover admin deletion in policy feature tests

## Testing
- `php artisan test` *(fails: AuthenticationTest, PasswordResetTest, CalendarReservationTest, ExampleTest, SurgeryRequestTest, plus missing env issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b091278b50832aae34818b7be69921