### PR TITLE
Block multiple day reservations on same date

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -45,7 +45,7 @@ class CalendarController extends Controller
         $this->authorize('create', DayReservation::class);
 
         $data = $request->validate([
-            'date' => ['required', 'date'],
+            'date' => ['required', 'date', 'unique:day_reservations,date'],
         ]);
 
         $reservation = DayReservation::create([

--- a/database/migrations/2025_08_28_124627_create_day_reservations_table.php
+++ b/database/migrations/2025_08_28_124627_create_day_reservations_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->enum('status', ['pending', 'confirmed'])->default('pending');
             $table->timestamps();
 
-            $table->unique(['doctor_id', 'date']);
+            $table->unique('date');
         });
     }
 

--- a/tests/Feature/DayReservationPolicyTest.php
+++ b/tests/Feature/DayReservationPolicyTest.php
@@ -35,6 +35,24 @@ class DayReservationPolicyTest extends TestCase
         ]);
     }
 
+    public function test_second_reservation_on_same_day_is_blocked(): void
+    {
+        $doctor1 = User::factory()->create();
+        $doctor1->assignRole('medico');
+
+        $date = now()->addDay()->toDateString();
+
+        $this->actingAs($doctor1)->postJson('/calendar', ['date' => $date])
+            ->assertStatus(201);
+
+        $doctor2 = User::factory()->create();
+        $doctor2->assignRole('medico');
+
+        $response = $this->actingAs($doctor2)->postJson('/calendar', ['date' => $date]);
+
+        $response->assertStatus(422)->assertJsonValidationErrors('date');
+    }
+
     public function test_nurse_cannot_create_day_reservation(): void
     {
         $nurse = User::factory()->create();


### PR DESCRIPTION
## Summary
- enforce unique reservation per date in migration and store controller
- validate date uniqueness in CalendarController
- test that second reservation on the same day returns validation error

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php <8.4)*
- `php artisan test` *(fails: vendor/autoload.php not found due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_68b09128ee88832aacd0a08822236fe8