### PR TITLE
feat: integrate fullcalendar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,10 @@
     "packages": {
         "": {
             "devDependencies": {
+                "@fullcalendar/core": "^6.1.19",
+                "@fullcalendar/daygrid": "^6.1.19",
+                "@fullcalendar/interaction": "^6.1.19",
+                "@fullcalendar/vue3": "^6.1.19",
                 "@inertiajs/vue3": "^1.0.0",
                 "@tailwindcss/forms": "^0.5.3",
                 "@vitejs/plugin-vue": "^5.0.0",
@@ -470,6 +474,47 @@
             ],
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@fullcalendar/core": {
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.19.tgz",
+            "integrity": "sha512-z0aVlO5e4Wah6p6mouM0UEqtRf1MZZPt4mwzEyU6kusaNL+dlWQgAasF2cK23hwT4cmxkEmr4inULXgpyeExdQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "preact": "~10.12.1"
+            }
+        },
+        "node_modules/@fullcalendar/daygrid": {
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.19.tgz",
+            "integrity": "sha512-IAAfnMICnVWPjpT4zi87i3FEw0xxSza0avqY/HedKEz+l5MTBYvCDPOWDATpzXoLut3aACsjktIyw9thvIcRYQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@fullcalendar/core": "~6.1.19"
+            }
+        },
+        "node_modules/@fullcalendar/interaction": {
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.19.tgz",
+            "integrity": "sha512-GOciy79xe8JMVp+1evAU3ytdwN/7tv35t5i1vFkifiuWcQMLC/JnLg/RA2s4sYmQwoYhTw/p4GLcP0gO5B3X5w==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@fullcalendar/core": "~6.1.19"
+            }
+        },
+        "node_modules/@fullcalendar/vue3": {
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/vue3/-/vue3-6.1.19.tgz",
+            "integrity": "sha512-j5eUSxx0xIy3ADljo0f5B9PhjqXnCQ+7nUMPfsslc2eGVjp4F74YvY3dyd6OBbg13IvpsjowkjncGipYMQWmTA==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@fullcalendar/core": "~6.1.19",
+                "vue": "^3.0.11"
             }
         },
         "node_modules/@inertiajs/core": {
@@ -2455,6 +2500,17 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/preact": {
+            "version": "10.12.1",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+            "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/preact"
+            }
         },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
         "build": "vite build && vite build --ssr"
     },
     "devDependencies": {
+        "@fullcalendar/core": "^6.1.19",
+        "@fullcalendar/daygrid": "^6.1.19",
+        "@fullcalendar/interaction": "^6.1.19",
+        "@fullcalendar/vue3": "^6.1.19",
         "@inertiajs/vue3": "^1.0.0",
         "@tailwindcss/forms": "^0.5.3",
         "@vitejs/plugin-vue": "^5.0.0",


### PR DESCRIPTION
## Summary
- install and configure FullCalendar
- rewrite calendar page to use FullCalendar with color-coded statuses and restricted cancel

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b0912d8078832a832c583a72828744