### PR TITLE
Remove day reservation status and confirmation flow

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -51,19 +51,9 @@ class CalendarController extends Controller
         $reservation = DayReservation::create([
             'doctor_id' => $request->user()->id,
             'date' => $data['date'],
-            'status' => 'pending',
         ]);
 
         return response()->json($reservation, 201);
-    }
-
-    public function confirm(DayReservation $dayReservation)
-    {
-        $this->authorize('confirm', $dayReservation);
-
-        $dayReservation->update(['status' => 'confirmed']);
-
-        return response()->json($dayReservation);
     }
 
     public function destroy(DayReservation $dayReservation)

--- a/app/Models/DayReservation.php
+++ b/app/Models/DayReservation.php
@@ -13,7 +13,6 @@ class DayReservation extends Model
     protected $fillable = [
         'doctor_id',
         'date',
-        'status',
     ];
 
     protected $casts = [

--- a/app/Policies/DayReservationPolicy.php
+++ b/app/Policies/DayReservationPolicy.php
@@ -12,11 +12,6 @@ class DayReservationPolicy
         return $user->hasRole('medico');
     }
 
-    public function confirm(User $user, DayReservation $reservation): bool
-    {
-        return $user->hasAnyRole(['enfermeiro', 'admin']);
-    }
-
     public function delete(User $user, DayReservation $reservation): bool
     {
         return $user->hasRole('admin') || (

--- a/database/migrations/2025_08_28_124627_create_day_reservations_table.php
+++ b/database/migrations/2025_08_28_124627_create_day_reservations_table.php
@@ -15,7 +15,6 @@ return new class extends Migration
             $table->id();
             $table->foreignId('doctor_id')->constrained('users')->cascadeOnDelete();
             $table->date('date')->index();
-            $table->enum('status', ['pending', 'confirmed'])->default('pending');
             $table->timestamps();
 
             $table->unique('date');

--- a/database/migrations/2025_08_28_124628_drop_status_from_day_reservations_table.php
+++ b/database/migrations/2025_08_28_124628_drop_status_from_day_reservations_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasColumn('day_reservations', 'status')) {
+            DB::table('day_reservations')->update(['status' => 'confirmed']);
+
+            Schema::table('day_reservations', function (Blueprint $table) {
+                $table->dropColumn('status');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('day_reservations', function (Blueprint $table) {
+            $table->enum('status', ['pending', 'confirmed'])->default('pending');
+        });
+    }
+};

--- a/resources/js/Pages/Calendar.vue
+++ b/resources/js/Pages/Calendar.vue
@@ -31,11 +31,11 @@ onMounted(fetchReservations);
 const events = computed(() =>
     reservations.value.map((r) => ({
         id: r.id,
-        title: r.status === 'pending' ? 'Pendente' : 'Confirmado',
+        title: 'Reservado',
         start: r.date,
         allDay: true,
-        backgroundColor: r.status === 'pending' ? '#f97316' : '#ef4444',
-        borderColor: r.status === 'pending' ? '#f97316' : '#ef4444',
+        backgroundColor: '#ef4444',
+        borderColor: '#ef4444',
         extendedProps: { reservation: r },
     }))
 );
@@ -48,13 +48,6 @@ async function handleDateSelect(selectionInfo) {
 
 async function handleEventClick(clickInfo) {
     const reservation = clickInfo.event.extendedProps.reservation;
-    if (reservation.status === 'pending' && hasRole('enfermeiro')) {
-        if (confirm('Confirmar reserva?')) {
-            await axios.post(`/calendar/${reservation.id}/confirm`);
-            await fetchReservations();
-        }
-        return;
-    }
     if (canCancel(reservation)) {
         if (confirm('Cancelar reserva?')) {
             await axios.delete(`/calendar/${reservation.id}`);

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,7 +52,6 @@ Route::middleware(['auth','verified','role:enfermeiro'])
 Route::middleware(['auth','role:medico|enfermeiro|admin'])->group(function () {
     Route::get('/calendar', [CalendarController::class, 'index'])->name('calendar');
     Route::post('/calendar', [CalendarController::class, 'store'])->name('day-reservations.store');
-    Route::post('/calendar/{dayReservation}/confirm', [CalendarController::class, 'confirm'])->name('day-reservations.confirm');
     Route::delete('/calendar/{dayReservation}', [CalendarController::class, 'destroy'])->name('day-reservations.destroy');
 });
 

--- a/tests/Feature/DayReservationPolicyTest.php
+++ b/tests/Feature/DayReservationPolicyTest.php
@@ -64,65 +64,6 @@ class DayReservationPolicyTest extends TestCase
             ->assertForbidden();
     }
 
-    public function test_nurse_can_confirm_day_reservation(): void
-    {
-        $doctor = User::factory()->create();
-        $doctor->assignRole('medico');
-        $nurse = User::factory()->create();
-        $nurse->assignRole('enfermeiro');
-
-        $reservation = DayReservation::create([
-            'doctor_id' => $doctor->id,
-            'date' => now()->addDay(),
-            'status' => 'pending',
-        ]);
-
-        $this->actingAs($nurse)->postJson("/calendar/{$reservation->id}/confirm")
-            ->assertOk();
-
-        $this->assertDatabaseHas('day_reservations', [
-            'id' => $reservation->id,
-            'status' => 'confirmed',
-        ]);
-    }
-
-    public function test_admin_can_confirm_day_reservation(): void
-    {
-        $doctor = User::factory()->create();
-        $doctor->assignRole('medico');
-        $admin = User::factory()->create();
-        $admin->assignRole('admin');
-
-        $reservation = DayReservation::create([
-            'doctor_id' => $doctor->id,
-            'date' => now()->addDay(),
-            'status' => 'pending',
-        ]);
-
-        $this->actingAs($admin)->postJson("/calendar/{$reservation->id}/confirm")
-            ->assertOk();
-
-        $this->assertDatabaseHas('day_reservations', [
-            'id' => $reservation->id,
-            'status' => 'confirmed',
-        ]);
-    }
-
-    public function test_doctor_cannot_confirm_day_reservation(): void
-    {
-        $doctor = User::factory()->create();
-        $doctor->assignRole('medico');
-
-        $reservation = DayReservation::create([
-            'doctor_id' => $doctor->id,
-            'date' => now()->addDay(),
-            'status' => 'pending',
-        ]);
-
-        $this->actingAs($doctor)->postJson("/calendar/{$reservation->id}/confirm")
-            ->assertForbidden();
-    }
-
     public function test_doctor_can_delete_own_day_reservation(): void
     {
         $doctor = User::factory()->create();
@@ -131,7 +72,6 @@ class DayReservationPolicyTest extends TestCase
         $reservation = DayReservation::create([
             'doctor_id' => $doctor->id,
             'date' => now()->addDay(),
-            'status' => 'pending',
         ]);
 
         $this->actingAs($doctor)->deleteJson("/calendar/{$reservation->id}")
@@ -152,7 +92,6 @@ class DayReservationPolicyTest extends TestCase
         $reservation = DayReservation::create([
             'doctor_id' => $doctor->id,
             'date' => now()->addDay(),
-            'status' => 'pending',
         ]);
 
         $this->actingAs($nurse)->deleteJson("/calendar/{$reservation->id}")
@@ -169,7 +108,6 @@ class DayReservationPolicyTest extends TestCase
         $reservation = DayReservation::create([
             'doctor_id' => $doctor->id,
             'date' => now()->addDay(),
-            'status' => 'pending',
         ]);
 
         $this->actingAs($admin)->deleteJson("/calendar/{$reservation->id}")


### PR DESCRIPTION
## Summary
- drop `status` from day reservations schema and clean existing data
- simplify calendar reservation model and controller
- remove status-based confirmation from calendar UI and routes

## Testing
- `composer install --ignore-platform-reqs`
- `./vendor/bin/phpunit` *(fails: Session is missing expected key [errors]; ExampleTest expecting 200 status but got 302)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a9e90dc8832aae103c5bbf8c07de