### PR TITLE
Remove reservation confirmation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Use these credentials to log in.
 
 Surgery requests now require a **room number** indicating where the procedure will take place.
 Rooms are numbered from 1 to 9 and the selected room is stored with each request.
+Reservations are confirmed immediately upon creation; no separate confirmation step is required.
 
 ### Validation rules
 

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -36,19 +36,7 @@ POST /surgery-requests
   "ok": "Solicitação criada!"
 }
 ```
-
-## Confirm reservation
-
-```bash
-POST /surgery-requests/{id}/approve
-```
-
-**Response**
-```json
-{
-  "ok": "Solicitação aprovada!"
-}
-```
+Reservations are confirmed immediately upon creation; no additional confirmation step is required.
 
 ## Cancel reservation
 

--- a/resources/js/Pages/Calendar.vue
+++ b/resources/js/Pages/Calendar.vue
@@ -31,11 +31,11 @@ onMounted(fetchReservations);
 const events = computed(() =>
     reservations.value.map((r) => ({
         id: r.id,
-        title: r.status === 'pending' ? 'Pendente' : 'Confirmado',
+        title: 'Confirmado',
         start: r.date,
         allDay: true,
-        backgroundColor: r.status === 'pending' ? '#f97316' : '#ef4444',
-        borderColor: r.status === 'pending' ? '#f97316' : '#ef4444',
+        backgroundColor: '#ef4444',
+        borderColor: '#ef4444',
         extendedProps: { reservation: r },
     }))
 );
@@ -48,13 +48,6 @@ async function handleDateSelect(selectionInfo) {
 
 async function handleEventClick(clickInfo) {
     const reservation = clickInfo.event.extendedProps.reservation;
-    if (reservation.status === 'pending' && hasRole('enfermeiro')) {
-        if (confirm('Confirmar reserva?')) {
-            await axios.post(`/calendar/${reservation.id}/confirm`);
-            await fetchReservations();
-        }
-        return;
-    }
     if (canCancel(reservation)) {
         if (confirm('Cancelar reserva?')) {
             await axios.delete(`/calendar/${reservation.id}`);


### PR DESCRIPTION
## Summary
- remove frontend calls to reservation confirmation endpoint
- document that reservations are confirmed upon creation

## Testing
- `npm run build`
- `php artisan test` *(fails: Session is missing expected key [errors])*

------
https://chatgpt.com/codex/tasks/task_e_68b1a9ebf22c832aa769f3054f5134ef