### PR TITLE
feat: include calendar query params

### DIFF
--- a/resources/js/Pages/Calendar.vue
+++ b/resources/js/Pages/Calendar.vue
@@ -8,6 +8,7 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 
 const reservations = ref([]);
+const roomNumber = ref(1);
 
 const page = usePage();
 const user = computed(() => page.props.auth.user);
@@ -22,7 +23,22 @@ const canCancel = (reservation) => {
 };
 
 async function fetchReservations() {
-    const { data } = await axios.get('/calendar');
+    const today = new Date();
+    const start = new Date(today.getFullYear(), today.getMonth(), 1)
+        .toISOString()
+        .slice(0, 10);
+    const end = new Date(today.getFullYear(), today.getMonth() + 1, 0)
+        .toISOString()
+        .slice(0, 10);
+
+    const { data } = await axios.get('/calendar', {
+        params: {
+            room_number: roomNumber.value,
+            start_date: start,
+            end_date: end,
+        },
+    });
+
     reservations.value = data;
 }
 


### PR DESCRIPTION
## Summary
- send room number and month date range when fetching calendar reservations

## Testing
- ⚠️ `npm run build` *(failed: Could not resolve `../../vendor/tightenco/ziggy` from `resources/js/app.js`)*
- ⚠️ `php artisan test` *(failed: vendor/autoload.php missing; composer install requires PHP <8.4)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f2daafc4832a9bf6c27a86423279