### PR TITLE
Restrict room numbers to eight

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -13,7 +13,7 @@ class CalendarController extends Controller
     {
         if ($request->wantsJson() || $request->query('room_number')) {
             $data = $request->validate([
-                'room_number' => ['required','integer','between:1,9'],
+                'room_number' => ['required','integer','between:1,8'],
                 'start_date'  => ['required','date'],
                 'end_date'    => ['required','date','after_or_equal:start_date'],
             ]);

--- a/app/Http/Requests/StoreSurgeryRequestRequest.php
+++ b/app/Http/Requests/StoreSurgeryRequestRequest.php
@@ -29,7 +29,7 @@ class StoreSurgeryRequestRequest extends FormRequest
             'date'         => ['required','date','after_or_equal:today'],
             'start_time'   => ['required','date_format:H:i'],
             'end_time'     => ['required','date_format:H:i','after:start_time'],
-            'room_number'  => ['required','integer','between:1,9'],
+            'room_number'  => ['required','integer','between:1,8'],
             'duration_minutes' => ['required','integer','min:1'],
             'patient_name' => ['required','string','max:120'],
             'procedure'    => ['required','string','max:160'],

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -7,7 +7,7 @@ GET /calendar?room_number=1&start_date=2025-01-01&end_date=2025-01-31
 ```
 
 Parameters:
-- `room_number`: required integer between 1 and 9.
+- `room_number`: required integer between 1 and 8.
 - `start_date` and `end_date`: required dates (end must be on or after start).
 
 The response is JSON ordered by date and start time and includes the `id`, `date`, `start_time`, `end_time`, `patient_name`, and

--- a/resources/js/Pages/Medico/NovaSolicitacao.vue
+++ b/resources/js/Pages/Medico/NovaSolicitacao.vue
@@ -86,7 +86,7 @@ const submit = () => {
                                 <InputLabel for="room_number" value="Sala" />
                                 <select id="room_number" class="mt-1 block w-full border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm" v-model="form.room_number" required :disabled="isApproved">
                                     <option value="" disabled>Selecione</option>
-                                    <option v-for="n in 9" :key="n" :value="n">Sala {{ n }}</option>
+                                    <option v-for="n in 8" :key="n" :value="n">Sala {{ n }}</option>
                                 </select>
                                 <InputError class="mt-2" :message="form.errors.room_number" />
                             </div>

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -76,5 +76,16 @@ class CalendarTest extends TestCase
         $response = $this->actingAs($user)->get('/calendar');
         $response->assertStatus(403);
     }
+
+    public function test_room_number_nine_is_invalid(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $response = $this->actingAs($doctor)->getJson('/calendar?room_number=9&start_date=2025-01-01&end_date=2025-01-31');
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['room_number']);
+    }
 }
 

--- a/tests/Feature/SurgeryRequestTest.php
+++ b/tests/Feature/SurgeryRequestTest.php
@@ -51,6 +51,26 @@ class SurgeryRequestTest extends TestCase
         ]);
     }
 
+    public function test_room_number_nine_fails_validation(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $payload = [
+            'date' => now()->addDay()->toDateString(),
+            'start_time' => '10:00',
+            'end_time' => '11:00',
+            'duration_minutes' => 60,
+            'room_number' => 9,
+            'patient_name' => 'John Doe',
+            'procedure' => 'Appendectomy',
+        ];
+
+        $response = $this->actingAs($doctor)->post('/surgery-requests', $payload);
+
+        $response->assertSessionHasErrors('room_number');
+    }
+
     public function test_end_time_is_calculated_when_missing(): void
     {
         $doctor = User::factory()->create();


### PR DESCRIPTION
## Summary
- limit calendar query and surgery requests to rooms 1-8
- show only eight rooms in new surgery request form
- document eight rooms and test invalid room 9

## Testing
- `npm run build`
- `./vendor/bin/phpunit` *(fails: Auth and Day reservation tests)*
- `./vendor/bin/phpunit tests/Feature/CalendarTest.php`
- `./vendor/bin/phpunit tests/Feature/SurgeryRequestTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b869c6c214832a9508b7525ddca0ed