### PR TITLE
Color-code surgery request statuses

### DIFF
--- a/resources/js/Pages/Enfermeiro/Solicitacoes.vue
+++ b/resources/js/Pages/Enfermeiro/Solicitacoes.vue
@@ -25,6 +25,13 @@ function cancel(id) {
         router.delete(route('surgery-requests.destroy', id));
     }
 }
+
+const statusClass = (status) => ({
+    requested: 'text-blue-600',
+    approved: 'text-green-600',
+    rejected: 'text-red-600',
+    cancelled: 'text-gray-600',
+}[status] || '');
 </script>
 
 <template>
@@ -65,7 +72,7 @@ function cancel(id) {
                             <tr v-for="req in requests.data" :key="req.id" class="border-t">
                                 <td class="px-3 py-2">{{ req.patient_name }}</td>
                                 <td class="px-3 py-2">{{ req.date }}</td>
-                                <td class="px-3 py-2">{{ req.status }}</td>
+                                <td class="px-3 py-2" :class="statusClass(req.status)">{{ req.status }}</td>
                                 <td class="px-3 py-2 text-right">
                                     <button v-if="req.can_cancel" @click="cancel(req.id)" class="text-red-600 hover:underline">Cancelar</button>
                                 </td>

--- a/resources/js/Pages/Medico/MinhasSolicitacoes.vue
+++ b/resources/js/Pages/Medico/MinhasSolicitacoes.vue
@@ -6,6 +6,13 @@ const props = defineProps({
     requests: Object,
 });
 
+const statusClass = (status) => ({
+    requested: 'text-blue-600',
+    approved: 'text-green-600',
+    rejected: 'text-red-600',
+    cancelled: 'text-gray-600',
+}[status] || '');
+
 function cancel(id) {
     if (confirm('Cancelar esta solicitação?')) {
         router.delete(route('surgery-requests.destroy', id));
@@ -36,7 +43,7 @@ function cancel(id) {
                             <tr v-for="req in requests.data" :key="req.id" class="border-t">
                                 <td class="px-3 py-2">{{ req.patient_name }}</td>
                                 <td class="px-3 py-2">{{ req.date }}</td>
-                                <td class="px-3 py-2">{{ req.status }}</td>
+                                <td class="px-3 py-2" :class="statusClass(req.status)">{{ req.status }}</td>
                                 <td class="px-3 py-2 text-right">
                                     <button v-if="req.can_cancel" @click="cancel(req.id)" class="text-red-600 hover:underline">Cancelar</button>
                                 </td>


### PR DESCRIPTION
## Summary
- add Tailwind statusClass helper to nurse and doctor request pages
- highlight request status text based on workflow state

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`
- `./vendor/bin/phpunit` (fails: 7 failures)

------
https://chatgpt.com/codex/tasks/task_e_68b869c7ac20832a8c38431cb8505c20