### PR TITLE
Ensure calendar requests use room, start and end dates

### DIFF
--- a/resources/js/Pages/Calendar.vue
+++ b/resources/js/Pages/Calendar.vue
@@ -17,13 +17,13 @@ const loadError = ref(null);
 async function fetchReservations() {
     loadError.value = null;
     try {
-        const response = await axios.get('/calendar', {
-            params: {
-                room_number: roomNumber.value,
-                start_date: startDate.value,
-                end_date: endDate.value,
-            },
-        });
+        const params = {
+            room_number: roomNumber.value,
+            start_date: startDate.value,
+            end_date: endDate.value,
+        };
+
+        const response = await axios.get('/calendar', { params });
         surgeries.value = response.data;
     } catch (error) {
         console.error('Failed to fetch surgeries', error);


### PR DESCRIPTION
## Summary
- Refine calendar reservation fetch to send only `room_number`, `start_date`, and `end_date` as query params

## Testing
- `node -e "import axios from 'axios'; console.log(axios.getUri({url:'/calendar', params:{room_number:1,start_date:'2025-01-01',end_date:'2025-01-31'}}));"`
- `./vendor/bin/phpunit` *(fails: Tests\Feature\DayReservationPolicyTest::test_different_doctors_can_reserve_same_day)*

------
https://chatgpt.com/codex/tasks/task_e_68b88e2b76fc832abd438a3554cd59cd