### PR TITLE
Allow admins to set doctor in exam reservations

### DIFF
--- a/app/Http/Controllers/ExamReservationController.php
+++ b/app/Http/Controllers/ExamReservationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\ExamReservation;
+use App\Models\User;
 use Illuminate\Http\Request;
 
 class ExamReservationController extends Controller
@@ -20,11 +21,28 @@ class ExamReservationController extends Controller
             'surgery_request_id' => ['nullable', 'exists:surgery_requests,id'],
             'exam_type' => ['required', 'string'],
             'date' => ['required', 'date'],
+            'doctor_id' => ['nullable', 'exists:users,id'],
         ]);
 
+        $doctorId = $request->input('doctor_id', $request->user()->id);
+
+        if ($request->user()->hasRole('admin')) {
+            $request->validate([
+                'doctor_id' => ['required'],
+            ]);
+
+            abort_unless(
+                User::find($doctorId)?->hasRole('medico'),
+                422,
+                'The selected doctor_id is invalid.'
+            );
+        }
+
+        unset($data['doctor_id']);
+
         $reservation = ExamReservation::create([
-            'doctor_id' => $request->user()->id,
             ...$data,
+            'doctor_id' => $doctorId,
         ]);
 
         return response()->json($reservation, 201);


### PR DESCRIPTION
## Summary
- Allow optional doctor assignment when creating exam reservations
- Require admins to specify a medico doctor for reservations

## Testing
- `./vendor/bin/phpunit` *(fails: Tests: 72, Assertions: 176, Failures: 8, Skipped: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b8920d0e88832ab94095bdf9346757