### PR TITLE
Add admin exam reservation creation test

### DIFF
--- a/tests/Feature/ExamReservationTest.php
+++ b/tests/Feature/ExamReservationTest.php
@@ -20,6 +20,29 @@ class ExamReservationTest extends TestCase
         app(PermissionRegistrar::class)->forgetCachedPermissions();
     }
 
+    public function test_admin_can_create_exam_reservation_for_doctor(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $payload = [
+            'doctor_id' => $doctor->id,
+            'exam_type' => 'Raio-X',
+            'date' => now()->addDay()->toDateString(),
+        ];
+
+        $this->actingAs($admin)->postJson('/exams', $payload)
+            ->assertStatus(201);
+
+        $this->assertDatabaseHas('exam_reservations', [
+            'doctor_id' => $doctor->id,
+            'exam_type' => 'Raio-X',
+        ]);
+    }
+
     public function test_doctor_can_create_exam_reservation(): void
     {
         $doctor = User::factory()->create();


### PR DESCRIPTION
## Summary
- add test ensuring admins can create exam reservations for doctors

## Testing
- `php artisan test` *(fails: Expected 201 status but received 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b892189708832a942bc02986aec1dd