### PR TITLE
Handle reservation dates and display fetch errors

### DIFF
--- a/resources/js/Pages/Calendar.vue
+++ b/resources/js/Pages/Calendar.vue
@@ -31,15 +31,15 @@ async function fetchReservations() {
     try {
         const params = {
             room_number: roomNumber.value,
-            start_date: startDate.value,
-            end_date: endDate.value,
+            start_date: new Date(startDate.value).toISOString().slice(0, 10),
+            end_date: new Date(endDate.value).toISOString().slice(0, 10),
         };
 
         const response = await axios.get('/calendar', { params });
         surgeries.value = response.data;
     } catch (error) {
         console.error('Failed to fetch surgeries', error);
-        loadError.value = 'Não foi possível carregar as cirurgias.';
+        loadError.value = error.response?.data?.message || 'Não foi possível carregar as cirurgias.';
     }
 }
 


### PR DESCRIPTION
## Summary
- Normalize start/end dates before fetching reservations
- Show server-provided error messages when reservation fetch fails

## Testing
- `npm run build` *(fails: Could not resolve '../../vendor/tightenco/ziggy')*
- `composer install` *(fails: PHP version 8.4 not satisfied)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c9438708832ab20e1dbd5fc003e6