### PR TITLE
feat: import fullcalendar styles

### DIFF
--- a/resources/js/Pages/Calendar.vue
+++ b/resources/js/Pages/Calendar.vue
@@ -1,4 +1,6 @@
 <script setup>
+import '@fullcalendar/core/index.css';
+import '@fullcalendar/daygrid/index.css';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head } from '@inertiajs/vue3';
 import { ref, computed, watch } from 'vue';


### PR DESCRIPTION
## Summary
- include FullCalendar core and daygrid CSS in calendar page

## Testing
- `npm run build` *(fails: Missing "./index.css" specifier in "@fullcalendar/core" package)*

------
https://chatgpt.com/codex/tasks/task_e_68bad1a635c4832a9f58cba6c8ca2265