### PR TITLE
Update FullCalendar CSS imports

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,7 +1,7 @@
 import './bootstrap';
 import '../css/app.css';
-import '@fullcalendar/core/index.css';
-import '@fullcalendar/daygrid/index.css';
+import '@fullcalendar/core/main.css';
+import '@fullcalendar/daygrid/main.css';
 
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';


### PR DESCRIPTION
## Summary
- switch FullCalendar CSS imports to use main.css for core and daygrid modules

## Testing
- `npm run build` *(fails: Missing "./main.css" specifier in "@fullcalendar/core" package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1d36d5a4832a90300e6725436e86